### PR TITLE
🔧 Chore: @Profile과 yml에 대한 리팩토링

### DIFF
--- a/insty-api/src/main/java/insty/global/config/SwaggerConfig.java
+++ b/insty-api/src/main/java/insty/global/config/SwaggerConfig.java
@@ -32,6 +32,7 @@ import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.method.HandlerMethod;
 
@@ -50,10 +51,11 @@ import org.springframework.web.method.HandlerMethod;
         in = io.swagger.v3.oas.annotations.enums.SecuritySchemeIn.HEADER, // 헤더에 담기
         paramName = "Authorization"          // 실제 헤더명
 )
+@Profile({"local, dev"})
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${swagger.server-url:https://localhost:8080/}")
+    @Value("${swagger.server-url}")
     private String swaggerServerUrl;
 
     @Bean

--- a/insty-api/src/main/resources/application-local.yml
+++ b/insty-api/src/main/resources/application-local.yml
@@ -3,4 +3,4 @@ spring:
     import: optional:file:.env[.properties]
 
 swagger:
-  server-url: http://localhost:8080/
+  server-url: http://localhost:8080

--- a/insty-api/src/main/resources/application-prod.yml
+++ b/insty-api/src/main/resources/application-prod.yml
@@ -1,2 +1,14 @@
-swagger:
-  server-url: ${SWAGGER_SERVER_URL}
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/insty-api/src/main/resources/application-test.yml
+++ b/insty-api/src/main/resources/application-test.yml
@@ -12,20 +12,24 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
 
-  # TODO detault 제거 개선
   security:
     jwt:
-      secret: ${JWT_SECRET_KEY:test-secret-key}
+      secret: test-secret-key
     cors:
-      allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
-      allowed-methods: ${CORS_ALLOWED_METHODS:OPTIONS,GET,POST,PUT,DELETE}
+      allowed-origins: http://localhost:3000
+      allowed-methods: OPTIONS,GET,POST,PUT,DELETE
 
   data:
     redis:
       host: test
       port: 1234
 
-# TODO detault 제거 개선
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
 oauth:
   providers:
     kakao:
@@ -51,8 +55,6 @@ oauth:
         user-info-url: test
       client_id: test
       client-secret: test
-
-
 
 app:
   health-check-path: /tmp

--- a/insty-external/src/main/java/insty/redis/config/RedisConfig.java
+++ b/insty-external/src/main/java/insty/redis/config/RedisConfig.java
@@ -8,8 +8,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
-@Configuration
 @Profile("!test")
+@Configuration
 @EnableRedisRepositories(basePackages = "insty.redis.repository")
 public class RedisConfig {
 


### PR DESCRIPTION
두 기술 사용에 혼동이 있어 개선사항으로 둔 부분을 개선한다
application.yml에 공통으로 선언한 필드가 있다면, 애플리케이션에서 사용하지 않더라도 값을 넣어두려는 시도로 인해 오류가 발생한다 여러 프로필 설정의 공통화는 포기할 수 없으므로 test yml에 재기록하여 default값을 넣는다