### PR TITLE
🐛 Fix: aws 액세스 키 통합

### DIFF
--- a/insty-api/src/main/resources/application.yml
+++ b/insty-api/src/main/resources/application.yml
@@ -70,17 +70,14 @@ oauth:
 
 
 aws:
-  region:
-    static: ${AWS_REGION}
+  region: ${AWS_REGION}
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
   s3:
     file:
       bucket: ${AWS_S3_FILE_BUCKET}
-      access-key: ${AWS_S3_FILE_ACCESS_KEY}
-      secret-key: ${AWS_S3_FILE_SECRET_KEY}
     video:
       upload-bucket: ${AWS_S3_VIDEO_UPLOAD_BUCKET}
-      access-key: ${AWS_S3_VIDEO_ACCESS_KEY}
-      secret-key: ${AWS_S3_VIDEO_SECRET_KEY}
   cloudfront:
     key-pair-id: ${AWS_CLOUDFRONT_KEY_PAIR_ID}
     private-key-path: ${AWS_CLOUDFRONT_PRIVATE_KEY_PATH}

--- a/insty-external/src/main/java/insty/s3/config/AwsS3Config.java
+++ b/insty-external/src/main/java/insty/s3/config/AwsS3Config.java
@@ -14,24 +14,18 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @Profile("!test")
 public class AwsS3Config {
 
-    @Value("${aws.region.static}")
+    @Value("${aws.region}")
     private String region;
 
-    @Value("${aws.s3.video.access-key}")
-    private String videoAccessKey;
+    @Value("${aws.access-key}")
+    private String accessKey;
 
-    @Value("${aws.s3.video.secret-key}")
-    private String videoSecretKey;
-
-    @Value("${aws.s3.file.access-key}")
-    private String fileAccessKey;
-
-    @Value("${aws.s3.file.secret-key}")
-    private String fileSecretKey;
+    @Value("${aws.secret-key}")
+    private String secretKey;
 
     @Bean
     public S3Presigner s3Presigner() {
-        AwsBasicCredentials credentials = AwsBasicCredentials.create(videoAccessKey, videoSecretKey);
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Presigner.builder()
                 .region(Region.of(region))
@@ -41,7 +35,7 @@ public class AwsS3Config {
 
     @Bean
     public S3Client s3Client() {
-        AwsBasicCredentials credentials = AwsBasicCredentials.create(fileAccessKey, fileSecretKey);
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Client.builder()
                 .region(Region.of(region))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * AWS 자격 증명 설정이 통합되어 관리가 간소화되었습니다. 이제 모든 S3 서비스에서 동일한 AWS 액세스 키와 시크릿 키를 사용합니다.
  * 구성 파일에서 AWS 관련 속성 구조가 정리되어 설정이 더 직관적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->