### PR TITLE
✨ Feat: 영상 업로드 제한에 대한 환경 별 분리

### DIFF
--- a/insty-api/src/main/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategy.java
+++ b/insty-api/src/main/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategy.java
@@ -1,11 +1,10 @@
 package insty.domain.video.strategy.videoAnswer;
 
-import static insty.constants.VideoConstants.VIDEO_ANSWER_UPLOAD_MINUTES_LIMIT;
-
 import insty.domain.video.repository.VideoAnswerRepository;
 import insty.domain.video.strategy.VideoValidateStrategy;
 import insty.error.VideoErrorCode;
 import insty.exception.CustomException;
+import insty.global.property.VideoUploadLimitProperties;
 import insty.model.video.EncodingStatus;
 import insty.model.video.VideoAnswer;
 import insty.util.DateUtils;
@@ -19,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class VideoAnswerValidateStrategy implements VideoValidateStrategy {
 
+    private final VideoUploadLimitProperties videoUploadLimitProperties;
+
     private final VideoAnswerRepository videoAnswerRepository;
 
     @Override
@@ -30,7 +31,7 @@ public class VideoAnswerValidateStrategy implements VideoValidateStrategy {
                 .stream()
                 .mapToInt(Integer::intValue)
                 .sum();
-        if (durationSum >= VIDEO_ANSWER_UPLOAD_MINUTES_LIMIT * 60) {
+        if (durationSum >= videoUploadLimitProperties.getAnswer() * 60) {
             throw new CustomException(VideoErrorCode.VIDEO_EXCEED_UPLOAD_LIMIT);
         }
     }

--- a/insty-api/src/main/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategy.java
+++ b/insty-api/src/main/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategy.java
@@ -1,11 +1,10 @@
 package insty.domain.video.strategy.videoCourse;
 
-import static insty.constants.VideoConstants.VIDEO_COURSE_UPLOAD_MINUTES_LIMIT;
-
 import insty.domain.video.repository.VideoCourseRepository;
 import insty.domain.video.strategy.VideoValidateStrategy;
 import insty.error.VideoErrorCode;
 import insty.exception.CustomException;
+import insty.global.property.VideoUploadLimitProperties;
 import insty.model.video.EncodingStatus;
 import insty.model.video.VideoCourse;
 import insty.util.DateUtils;
@@ -19,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class VideoCourseValidateStrategy implements VideoValidateStrategy {
 
+    private final VideoUploadLimitProperties videoUploadLimitProperties;
+
     private final VideoCourseRepository videoCourseRepository;
 
     @Override
@@ -30,7 +31,7 @@ public class VideoCourseValidateStrategy implements VideoValidateStrategy {
                 .stream()
                 .mapToInt(Integer::intValue)
                 .sum();
-        if (durationSum >= VIDEO_COURSE_UPLOAD_MINUTES_LIMIT * 60) {
+        if (durationSum >= videoUploadLimitProperties.getCourse() * 60) {
             throw new CustomException(VideoErrorCode.VIDEO_EXCEED_UPLOAD_LIMIT);
         }
     }

--- a/insty-api/src/main/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategy.java
+++ b/insty-api/src/main/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategy.java
@@ -1,11 +1,10 @@
 package insty.domain.video.strategy.videoQuestion;
 
-import static insty.constants.VideoConstants.VIDEO_QUESTION_UPLOAD_MINUTES_LIMIT;
-
 import insty.domain.video.repository.VideoQuestionRepository;
 import insty.domain.video.strategy.VideoValidateStrategy;
 import insty.error.VideoErrorCode;
 import insty.exception.CustomException;
+import insty.global.property.VideoUploadLimitProperties;
 import insty.model.video.EncodingStatus;
 import insty.model.video.VideoQuestion;
 import insty.util.DateUtils;
@@ -19,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class VideoQuestionValidateStrategy implements VideoValidateStrategy {
 
+    private final VideoUploadLimitProperties videoUploadLimitProperties;
+
     private final VideoQuestionRepository videoQuestionRepository;
 
     @Override
@@ -30,7 +31,7 @@ public class VideoQuestionValidateStrategy implements VideoValidateStrategy {
                 .stream()
                 .mapToInt(Integer::intValue)
                 .sum();
-        if (durationSum >= VIDEO_QUESTION_UPLOAD_MINUTES_LIMIT * 60) {
+        if (durationSum >= videoUploadLimitProperties.getQuestion() * 60) {
             throw new CustomException(VideoErrorCode.VIDEO_EXCEED_UPLOAD_LIMIT);
         }
     }

--- a/insty-api/src/main/java/insty/global/property/VideoUploadLimitProperties.java
+++ b/insty-api/src/main/java/insty/global/property/VideoUploadLimitProperties.java
@@ -1,0 +1,17 @@
+package insty.global.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "video.upload.max-minute")
+public class VideoUploadLimitProperties {
+
+    private int course;
+    private int question;
+    private int answer;
+}

--- a/insty-api/src/main/resources/application-dev.yml
+++ b/insty-api/src/main/resources/application-dev.yml
@@ -13,6 +13,6 @@ swagger:
 video:
   upload:
     max-minute:
-      course: 2
-      answer: 2
-      question: 2
+      course: 60
+      answer: 60
+      question: 60

--- a/insty-api/src/main/resources/application-dev.yml
+++ b/insty-api/src/main/resources/application-dev.yml
@@ -9,3 +9,10 @@ spring:
 
 swagger:
   server-url: ${SWAGGER_SERVER_URL}
+
+video:
+  upload:
+    max-minute:
+      course: 2
+      answer: 2
+      question: 2

--- a/insty-api/src/main/resources/application.yml
+++ b/insty-api/src/main/resources/application.yml
@@ -98,5 +98,5 @@ video:
   upload:
     max-minute:
       course: 30
-      answer: 5
-      question: 5
+      answer: 10
+      question: 10

--- a/insty-api/src/main/resources/application.yml
+++ b/insty-api/src/main/resources/application.yml
@@ -93,3 +93,10 @@ app:
 logging:
   level:
     org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport: WARN
+
+video:
+  upload:
+    max-minute:
+      course: 30
+      answer: 5
+      question: 5

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategyTest.java
@@ -41,17 +41,17 @@ class VideoAnswerValidateStrategyTest {
     @BeforeEach
     void setUp() {
         lenient().when(videoUploadLimitProperties.getAnswer())
-                .thenReturn(5);
+                .thenReturn(10);
     }
 
     @Test
-    void validateUploadable_정상_오늘_생성한_영상_총_길이가_5분_미만이다() {
+    void validateUploadable_정상_오늘_생성한_영상_총_길이가_10분_미만이다() {
         // given
         Long userId = 1L;
 
         // mock
         when(videoAnswerRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
-                .thenReturn(List.of(60, 239));
+                .thenReturn(List.of(60, 239, 300));
 
         // when
 
@@ -61,13 +61,13 @@ class VideoAnswerValidateStrategyTest {
     }
 
     @Test
-    void validateUploadable_에러_오늘_생성한_영상_총_길이가_5분_이상이다() {
+    void validateUploadable_에러_오늘_생성한_영상_총_길이가_10분_이상이다() {
         // given
         Long userId = 1L;
 
         // mock
         when(videoAnswerRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
-                .thenReturn(List.of(60, 240));
+                .thenReturn(List.of(60, 240, 300));
 
         // when
 

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategyTest.java
@@ -3,17 +3,20 @@ package insty.domain.video.strategy.videoAnswer;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import insty.domain.video.repository.VideoAnswerRepository;
 import insty.error.VideoErrorCode;
 import insty.exception.CustomException;
+import insty.global.property.VideoUploadLimitProperties;
 import insty.model.video.EncodingStatus;
 import insty.model.video.VideoAnswer;
 import insty.model.video.VideoFixtureBuilder;
 import insty.model.video.VideoType;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +33,16 @@ class VideoAnswerValidateStrategyTest {
     private VideoAnswerValidateStrategy videoAnswerValidateStrategy;
 
     @Mock
+    private VideoUploadLimitProperties videoUploadLimitProperties;
+    @Mock
     private VideoAnswerRepository videoAnswerRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(videoUploadLimitProperties.getAnswer())
+                .thenReturn(5);
+    }
 
     @Test
     void validateUploadable_정상_오늘_생성한_영상_총_길이가_5분_미만이다() {

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategyTest.java
@@ -3,16 +3,19 @@ package insty.domain.video.strategy.videoCourse;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import insty.domain.video.repository.VideoCourseRepository;
 import insty.error.VideoErrorCode;
 import insty.exception.CustomException;
+import insty.global.property.VideoUploadLimitProperties;
 import insty.model.video.EncodingStatus;
 import insty.model.video.VideoCourse;
 import insty.model.video.VideoFixtureBuilder;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +32,16 @@ class VideoCourseValidateStrategyTest {
     private VideoCourseValidateStrategy videoCourseValidateStrategy;
 
     @Mock
+    private VideoUploadLimitProperties videoUploadLimitProperties;
+    @Mock
     private VideoCourseRepository videoCourseRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(videoUploadLimitProperties.getCourse())
+                .thenReturn(30);
+    }
 
     @Test
     void validateUploadable_정상_오늘_생성한_영상_총_길이가_30분_미만이다() {

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategyTest.java
@@ -40,17 +40,17 @@ class VideoQuestionValidateStrategyTest {
     @BeforeEach
     void setUp() {
         lenient().when(videoUploadLimitProperties.getQuestion())
-                .thenReturn(5);
+                .thenReturn(10);
     }
 
     @Test
-    void validateUploadable_정상_오늘_생성한_영상_총_길이가_5분_미만이다() {
+    void validateUploadable_정상_오늘_생성한_영상_총_길이가_10분_미만이다() {
         // given
         Long userId = 1L;
 
         // mock
         when(videoQuestionRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
-                .thenReturn(List.of(60, 239));
+                .thenReturn(List.of(60, 239, 300));
 
         // when
 
@@ -60,13 +60,13 @@ class VideoQuestionValidateStrategyTest {
     }
 
     @Test
-    void validateUploadable_에러_오늘_생성한_영상_총_길이가_5분_이상이다() {
+    void validateUploadable_에러_오늘_생성한_영상_총_길이가_10분_이상이다() {
         // given
         Long userId = 1L;
 
         // mock
         when(videoQuestionRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
-                .thenReturn(List.of(60, 240));
+                .thenReturn(List.of(60, 240, 300));
 
         // when
 

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategyTest.java
@@ -3,16 +3,19 @@ package insty.domain.video.strategy.videoQuestion;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import insty.domain.video.repository.VideoQuestionRepository;
 import insty.error.VideoErrorCode;
 import insty.exception.CustomException;
+import insty.global.property.VideoUploadLimitProperties;
 import insty.model.video.EncodingStatus;
 import insty.model.video.VideoFixtureBuilder;
 import insty.model.video.VideoQuestion;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +32,16 @@ class VideoQuestionValidateStrategyTest {
     private VideoQuestionValidateStrategy videoQuestionValidateStrategy;
 
     @Mock
+    private VideoUploadLimitProperties videoUploadLimitProperties;
+    @Mock
     private VideoQuestionRepository videoQuestionRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(videoUploadLimitProperties.getQuestion())
+                .thenReturn(5);
+    }
 
     @Test
     void validateUploadable_정상_오늘_생성한_영상_총_길이가_5분_미만이다() {

--- a/insty-common/src/main/java/insty/constants/VideoConstants.java
+++ b/insty-common/src/main/java/insty/constants/VideoConstants.java
@@ -6,9 +6,6 @@ public class VideoConstants {
 
     public static final String DOMAIN = "Domain";
     public static final String PATH = "Path";
-    public static final int VIDEO_COURSE_UPLOAD_MINUTES_LIMIT = 30;
-    public static final int VIDEO_QUESTION_UPLOAD_MINUTES_LIMIT = 5;
-    public static final int VIDEO_ANSWER_UPLOAD_MINUTES_LIMIT = 5;
     public static final String PREVIEW_BASE_FOLDER = "preview";
 
     public static final long VIDEO_EXPIRATION_MINUTES = 360L;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 동영상 업로드 시간 제한을 외부 설정 파일에서 관리할 수 있도록 개선되었습니다. 각 동영상 유형(강의, 질문, 답변)에 대해 업로드 가능한 최대 시간이 설정에서 지정됩니다.

* **문서**
  * 설정 파일(application.yml, application-dev.yml)에 동영상 업로드 시간 제한 항목이 추가되었습니다.

* **테스트**
  * 동영상 업로드 시간 제한 관련 테스트 코드가 새로운 설정 방식에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->