### PR TITLE
🐛 Fix: 인코딩에 실패한 영상은 업로드 제한 범위에 포함되지 않도록 수정

### DIFF
--- a/insty-api/src/main/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategy.java
+++ b/insty-api/src/main/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategy.java
@@ -26,8 +26,8 @@ public class VideoAnswerValidateStrategy implements VideoValidateStrategy {
     public void validateUploadable(Long userId) {
         Instant startOfToday = DateUtils.getStartOfTodayInKorea();
 
-        int durationSum = videoAnswerRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(userId,
-                        startOfToday)
+        int durationSum = videoAnswerRepository.findEncodingDuration(userId, startOfToday,
+                        EncodingStatus.getExceedUploadLimitTarget())
                 .stream()
                 .mapToInt(Integer::intValue)
                 .sum();

--- a/insty-api/src/main/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategy.java
+++ b/insty-api/src/main/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategy.java
@@ -26,8 +26,8 @@ public class VideoCourseValidateStrategy implements VideoValidateStrategy {
     public void validateUploadable(Long userId) {
         Instant startOfToday = DateUtils.getStartOfTodayInKorea();
 
-        int durationSum = videoCourseRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(userId,
-                        startOfToday)
+        int durationSum = videoCourseRepository.findEncodingDuration(userId, startOfToday,
+                        EncodingStatus.getExceedUploadLimitTarget())
                 .stream()
                 .mapToInt(Integer::intValue)
                 .sum();

--- a/insty-api/src/main/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategy.java
+++ b/insty-api/src/main/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategy.java
@@ -26,8 +26,8 @@ public class VideoQuestionValidateStrategy implements VideoValidateStrategy {
     public void validateUploadable(Long userId) {
         Instant startOfToday = DateUtils.getStartOfTodayInKorea();
 
-        int durationSum = videoQuestionRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(userId,
-                        startOfToday)
+        int durationSum = videoQuestionRepository.findEncodingDuration(userId, startOfToday,
+                        EncodingStatus.getExceedUploadLimitTarget())
                 .stream()
                 .mapToInt(Integer::intValue)
                 .sum();

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoAnswer/VideoAnswerValidateStrategyTest.java
@@ -50,7 +50,7 @@ class VideoAnswerValidateStrategyTest {
         Long userId = 1L;
 
         // mock
-        when(videoAnswerRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
+        when(videoAnswerRepository.findEncodingDuration(any(), any(), any()))
                 .thenReturn(List.of(60, 239, 300));
 
         // when
@@ -66,7 +66,7 @@ class VideoAnswerValidateStrategyTest {
         Long userId = 1L;
 
         // mock
-        when(videoAnswerRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
+        when(videoAnswerRepository.findEncodingDuration(any(), any(), any()))
                 .thenReturn(List.of(60, 240, 300));
 
         // when

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoCourse/VideoCourseValidateStrategyTest.java
@@ -49,7 +49,7 @@ class VideoCourseValidateStrategyTest {
         Long userId = 1L;
 
         // mock
-        when(videoCourseRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
+        when(videoCourseRepository.findEncodingDuration(any(), any(), any()))
                 .thenReturn(List.of(60, 1600, 139));
 
         // when
@@ -65,7 +65,7 @@ class VideoCourseValidateStrategyTest {
         Long userId = 1L;
 
         // mock
-        when(videoCourseRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
+        when(videoCourseRepository.findEncodingDuration(any(), any(), any()))
                 .thenReturn(List.of(60, 1600, 140));
 
         // when

--- a/insty-api/src/test/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategyTest.java
+++ b/insty-api/src/test/java/insty/domain/video/strategy/videoQuestion/VideoQuestionValidateStrategyTest.java
@@ -49,7 +49,7 @@ class VideoQuestionValidateStrategyTest {
         Long userId = 1L;
 
         // mock
-        when(videoQuestionRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
+        when(videoQuestionRepository.findEncodingDuration(any(), any(), any()))
                 .thenReturn(List.of(60, 239, 300));
 
         // when
@@ -65,7 +65,7 @@ class VideoQuestionValidateStrategyTest {
         Long userId = 1L;
 
         // mock
-        when(videoQuestionRepository.findEncodingDurationByUserIdAndEncodingAtGreaterThan(any(), any()))
+        when(videoQuestionRepository.findEncodingDuration(any(), any(), any()))
                 .thenReturn(List.of(60, 240, 300));
 
         // when

--- a/insty-domain/src/main/java/insty/domain/video/repository/VideoAnswerRepository.java
+++ b/insty-domain/src/main/java/insty/domain/video/repository/VideoAnswerRepository.java
@@ -1,5 +1,6 @@
 package insty.domain.video.repository;
 
+import insty.model.video.EncodingStatus;
 import insty.model.video.VideoAnswer;
 import java.time.Instant;
 import java.util.List;
@@ -27,9 +28,9 @@ public interface VideoAnswerRepository extends JpaRepository<VideoAnswer, Long> 
     void deleteLogicallyById(@Param("id") Long id);
 
     @Query("SELECT va.duration FROM VideoAnswer va "
-            + "WHERE va.encodingStatus != 'FAILED' AND va.user.id = :userId AND va.encodingAt >= :encodingAt")
-    List<Integer> findEncodingDurationByUserIdAndEncodingAtGreaterThan(@Param("userId") Long userId,
-                                                                       @Param("encodingAt") Instant encodingAt);
+            + "WHERE va.user.id = :userId AND va.encodingAt >= :encodingAt AND va.encodingStatus in :encodingStatus")
+    List<Integer> findEncodingDuration(@Param("userId") Long userId, @Param("encodingAt") Instant encodingAt,
+                                       @Param("encodingStatus") List<EncodingStatus> encodingStatuses);
 
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/insty-domain/src/main/java/insty/domain/video/repository/VideoCourseRepository.java
+++ b/insty-domain/src/main/java/insty/domain/video/repository/VideoCourseRepository.java
@@ -1,5 +1,6 @@
 package insty.domain.video.repository;
 
+import insty.model.video.EncodingStatus;
 import insty.model.video.VideoCourse;
 import java.time.Instant;
 import java.util.List;
@@ -21,9 +22,9 @@ public interface VideoCourseRepository extends JpaRepository<VideoCourse, Long> 
     List<VideoCourse> findAllByCourseIdIn(List<Long> courseIds);
 
     @Query("SELECT vc.duration FROM VideoCourse vc "
-            + "WHERE vc.encodingStatus != 'FAILED' AND vc.user.id = :userId AND vc.encodingAt >= :encodingAt")
-    List<Integer> findEncodingDurationByUserIdAndEncodingAtGreaterThan(@Param("userId") Long userId,
-                                                                       @Param("encodingAt") Instant encodingAt);
+            + "WHERE vc.user.id = :userId AND vc.encodingAt >= :encodingAt AND vc.encodingStatus in :encodingStatus")
+    List<Integer> findEncodingDuration(@Param("userId") Long userId, @Param("encodingAt") Instant encodingAt,
+                                       @Param("encodingStatus") List<EncodingStatus> encodingStatuses);
 
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/insty-domain/src/main/java/insty/domain/video/repository/VideoQuestionRepository.java
+++ b/insty-domain/src/main/java/insty/domain/video/repository/VideoQuestionRepository.java
@@ -1,5 +1,6 @@
 package insty.domain.video.repository;
 
+import insty.model.video.EncodingStatus;
 import insty.model.video.VideoQuestion;
 import java.time.Instant;
 import java.util.List;
@@ -26,9 +27,9 @@ public interface VideoQuestionRepository extends JpaRepository<VideoQuestion, Lo
     void deleteLogicallyById(@Param("id") Long id);
 
     @Query("SELECT va.duration FROM VideoQuestion va "
-            + "WHERE va.encodingStatus != 'FAILED' AND va.user.id = :userId AND va.encodingAt >= :encodingAt")
-    List<Integer> findEncodingDurationByUserIdAndEncodingAtGreaterThan(@Param("userId") Long userId,
-                                                                       @Param("encodingAt") Instant encodingAt);
+            + "WHERE va.user.id = :userId AND va.encodingAt >= :encodingAt AND va.encodingStatus in :encodingStatus")
+    List<Integer> findEncodingDuration(@Param("userId") Long userId, @Param("encodingAt") Instant encodingAt,
+                                       @Param("encodingStatus") List<EncodingStatus> encodingStatuses);
 
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/insty-domain/src/main/java/insty/model/video/EncodingStatus.java
+++ b/insty-domain/src/main/java/insty/model/video/EncodingStatus.java
@@ -1,10 +1,16 @@
 package insty.model.video;
 
+import java.util.List;
+
 public enum EncodingStatus {
     WAITING,
     PROCESSING,
     COMPLETED,
     FAILED,
     FAILED_INVALID_VIDEO_LENGTH,
-    FAILED_NOT_FOUND_VOICE
+    FAILED_NOT_FOUND_VOICE;
+
+    public static List<EncodingStatus> getExceedUploadLimitTarget() {
+        return List.of(WAITING, PROCESSING, COMPLETED);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 동영상 업로드 제한 계산을 수정해 오늘 기준 누적 시간 집계 시 인코딩 상태(대기/처리중/완료)만 합산하도록 변경했습니다. 잘못된 제한 초과 경고/차단이 줄어들며, 답변/강의/질문 영상 검증에 동일 적용됩니다.

- 개선
  - 업로드 제한 판단의 일관성과 정확도를 향상하여 예기치 않은 업로드 차단을 감소시키고 사용자 경험을 안정화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->