### PR TITLE
✨ Feat(payment): 카카오페이 결제 외부 통신 구현

### DIFF
--- a/insty-api/src/main/resources/application-test.yml
+++ b/insty-api/src/main/resources/application-test.yml
@@ -56,6 +56,11 @@ oauth:
       client_id: test
       client-secret: test
 
+kakaopay:
+  timeout:
+    connectMillis: 5000
+    readMillis: 10000
+
 app:
   health-check-path: /tmp
   domain: "domain"

--- a/insty-external/src/main/java/insty/payment/kakaopay/config/KakaoPayRestClientConfig.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/config/KakaoPayRestClientConfig.java
@@ -1,0 +1,62 @@
+package insty.payment.kakaopay.config;
+
+import insty.payment.kakaopay.properties.KakaoPayProperties;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(KakaoPayProperties.class)
+public class KakaoPayRestClientConfig {
+
+    // 카카오페이 API 인증 헤더 키
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+
+    // 카카오페이 인증 스킴 접두사
+    private static final String AUTH_SCHEME_SECRET_KEY = "SECRET_KEY ";
+
+    // 카카오페이 전용 RestClient Bean 생성
+    @Bean(name = "kakaopayRestClient")
+    public RestClient kakaopayRestClient(KakaoPayProperties kakaoPayProperties) {
+        // KakaoPayProperties 기반으로 타임아웃 설정된 RequestFactory 생성
+        ClientHttpRequestFactory clientHttpRequestFactory = buildRequestFactory(kakaoPayProperties);
+
+        // 카카오페이 API 전용 RestClient 빌드
+        return RestClient.builder()
+                .baseUrl(kakaoPayProperties.host()) // 카카오페이 API 기본 호스트
+                .requestFactory(clientHttpRequestFactory) // 타임아웃이 적용된 HTTP 클라이언트
+                .defaultHeader(HEADER_AUTHORIZATION, AUTH_SCHEME_SECRET_KEY + kakaoPayProperties.secretKey()) // 인증 헤더
+                .defaultHeader("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE) // 기본 Content-Type
+                .build();
+    }
+
+    // JDK HttpClient 기반 RequestFactory 생성 (연결/응답 타임아웃 적용)
+    private ClientHttpRequestFactory buildRequestFactory(KakaoPayProperties kakaoPayProperties) {
+        // 연결 타임아웃 (ms), 값이 없으면 기본 3000
+        int connectTimeoutMillis = kakaoPayProperties.timeout().connectMillis() != null
+                ? kakaoPayProperties.timeout().connectMillis()
+                : 3000;
+
+        // 응답 타임아웃 (ms), 값이 없으면 기본 5000
+        int readTimeoutMillis = kakaoPayProperties.timeout().readMillis() != null
+                ? kakaoPayProperties.timeout().readMillis()
+                : 5000;
+
+        // JDK HttpClient 생성 (연결 타임아웃 적용)
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(connectTimeoutMillis))
+                .build();
+
+        // JdkClientHttpRequestFactory 생성 및 응답 타임아웃 설정
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMillis));
+
+        return requestFactory;
+    }
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveDto.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveDto.java
@@ -1,0 +1,14 @@
+package insty.payment.kakaopay.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// 카카오 Approve API 원문 응답 DTO (내부 전용)
+public record KakaoPayApproveDto(
+
+        // 요청 고유 id
+        String aid,
+
+        // 승인 완료 시각 (approved_at → approvedAt 매핑)
+        @JsonProperty("approved_at")
+        String approvedAt
+) {}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveDto.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveDto.java
@@ -1,11 +1,14 @@
 package insty.payment.kakaopay.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 // 카카오 Approve API 원문 응답 DTO (내부 전용)
 public record KakaoPayApproveDto(
 
         // 요청 고유 id
         String aid,
 
-        // 승인 완료 시각
+        // 승인 완료 시각 (approved_at → approvedAt)
+        @JsonProperty("approved_at")
         String approvedAt
 ) {}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveDto.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveDto.java
@@ -1,14 +1,11 @@
 package insty.payment.kakaopay.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 // 카카오 Approve API 원문 응답 DTO (내부 전용)
 public record KakaoPayApproveDto(
 
         // 요청 고유 id
         String aid,
 
-        // 승인 완료 시각 (approved_at → approvedAt 매핑)
-        @JsonProperty("approved_at")
+        // 승인 완료 시각
         String approvedAt
 ) {}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveReq.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveReq.java
@@ -1,23 +1,17 @@
 package insty.payment.kakaopay.dto;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record KakaoPayApproveReq(
 
         // 파트너 주문번호
-        @NotBlank
         String orderId,
 
         // 파트너 사용자 식별자
-        @NotBlank
         String userId,
 
         // 결제 준비 단계에서 발급받은 tid
-        @NotBlank
         String tid,
 
         // 카카오 콜백에서 전달받은 pg_token
-        @NotBlank
         String pgToken
 ) {
     public static KakaoPayApproveReq of(String orderId, String userId, String tid, String pgToken) {

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveReq.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveReq.java
@@ -1,0 +1,26 @@
+package insty.payment.kakaopay.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoPayApproveReq(
+
+        // 파트너 주문번호
+        @NotBlank
+        String orderId,
+
+        // 파트너 사용자 식별자
+        @NotBlank
+        String userId,
+
+        // 결제 준비 단계에서 발급받은 tid
+        @NotBlank
+        String tid,
+
+        // 카카오 콜백에서 전달받은 pg_token
+        @NotBlank
+        String pgToken
+) {
+    public static KakaoPayApproveReq of(String orderId, String userId, String tid, String pgToken) {
+        return new KakaoPayApproveReq(orderId, userId, tid, pgToken);
+    }
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveRes.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveRes.java
@@ -1,0 +1,17 @@
+package insty.payment.kakaopay.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KakaoPayApproveRes(
+        // 요청 고유 id
+        String aid,
+
+        // 승인 완료 시각
+        String approvedAt
+) {
+    public static KakaoPayApproveRes of(String aid, String approvedAt) {
+        return new KakaoPayApproveRes(aid, approvedAt);
+    }
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveRes.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayApproveRes.java
@@ -1,9 +1,5 @@
 package insty.payment.kakaopay.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record KakaoPayApproveRes(
         // 요청 고유 id
         String aid,

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyDto.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyDto.java
@@ -1,7 +1,5 @@
 package insty.payment.kakaopay.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 // 카카오 Ready API 원문 응답 DTO (내부 전용)
 public record KakaoPayReadyDto(
 
@@ -9,14 +7,11 @@ public record KakaoPayReadyDto(
         String tid,
 
         // PC 리다이렉트 URL
-        @JsonProperty("next_redirect_pc_url")
         String nextRedirectPcUrl,
 
         // 모바일 리다이렉트 URL
-        @JsonProperty("next_redirect_mobile_url")
         String nextRedirectMobileUrl,
 
         // 앱 리다이렉트 URL
-        @JsonProperty("next_redirect_app_url")
         String nextRedirectAppUrl
 ) {}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyDto.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyDto.java
@@ -1,0 +1,22 @@
+package insty.payment.kakaopay.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// 카카오 Ready API 원문 응답 DTO (내부 전용)
+public record KakaoPayReadyDto(
+
+        // 카카오페이 결제 고유 id
+        String tid,
+
+        // PC 리다이렉트 URL
+        @JsonProperty("next_redirect_pc_url")
+        String nextRedirectPcUrl,
+
+        // 모바일 리다이렉트 URL
+        @JsonProperty("next_redirect_mobile_url")
+        String nextRedirectMobileUrl,
+
+        // 앱 리다이렉트 URL
+        @JsonProperty("next_redirect_app_url")
+        String nextRedirectAppUrl
+) {}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyDto.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyDto.java
@@ -1,17 +1,22 @@
 package insty.payment.kakaopay.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 // 카카오 Ready API 원문 응답 DTO (내부 전용)
 public record KakaoPayReadyDto(
 
         // 카카오페이 결제 고유 id
         String tid,
 
-        // PC 리다이렉트 URL
+        // PC 리다이렉트 URL (next_redirect_pc_url → nextRedirectPcUrl)
+        @JsonProperty("next_redirect_pc_url")
         String nextRedirectPcUrl,
 
         // 모바일 리다이렉트 URL
+        @JsonProperty("next_redirect_mobile_url")
         String nextRedirectMobileUrl,
 
         // 앱 리다이렉트 URL
+        @JsonProperty("next_redirect_app_url")
         String nextRedirectAppUrl
 ) {}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
@@ -43,6 +43,14 @@ public record KakaoPayReadyReq(
         int normalizedTotalAmount = requirePositive(totalAmount, "totalAmount");
         int normalizedTaxFreeAmount = normalizeNonNegative(taxFreeAmount);
 
+        // 비과세 금액은 총 결제금액을 초과할 수 없음
+        if (normalizedTaxFreeAmount > normalizedTotalAmount) {
+            throw new IllegalArgumentException(
+                    "taxFreeAmount must be <= totalAmount (taxFreeAmount=" +
+                            normalizedTaxFreeAmount + ", totalAmount=" + normalizedTotalAmount + ")"
+            );
+        }
+
         return new KakaoPayReadyReq(
                 normalizedOrderId,
                 normalizedUserId,

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
@@ -1,49 +1,32 @@
 package insty.payment.kakaopay.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
-
 public record KakaoPayReadyReq(
 
         // 파트너 주문번호
-        @NotBlank
         String orderId,
 
         // 파트너 사용자 식별자
-        @NotBlank
         String userId,
 
         // 상품명
-        @NotBlank
         String itemName,
 
         // 수량
-        @NotNull
-        @Positive
         Integer quantity,
 
         // 총 결제금액
-        @NotNull
-        @Positive
         Integer totalAmount,
 
         // 비과세 금액
-        @NotNull
-        @PositiveOrZero
         Integer taxFreeAmount,
 
         // 결제성공 리다이렉트 URL
-        @NotBlank
         String approvalUrl,
 
         // 결제취소 리다이렉트 URL (사용자 취소)
-        @NotBlank
         String cancelUrl,
 
         // 결제실패 리다이렉트 URL
-        @NotBlank
         String failUrl
 ) {
     public static KakaoPayReadyReq of(

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
@@ -1,0 +1,64 @@
+package insty.payment.kakaopay.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record KakaoPayReadyReq(
+
+        // 파트너 주문번호
+        @NotBlank
+        String orderId,
+
+        // 파트너 사용자 식별자
+        @NotBlank
+        String userId,
+
+        // 상품명
+        @NotBlank
+        String itemName,
+
+        // 수량
+        @NotNull
+        @Positive
+        Integer quantity,
+
+        // 총 결제금액
+        @NotNull
+        @Positive
+        Integer totalAmount,
+
+        // 비과세 금액
+        @NotNull
+        @PositiveOrZero
+        Integer taxFreeAmount,
+
+        // 결제성공 리다이렉트 URL
+        @NotBlank
+        String approvalUrl,
+
+        // 결제취소 리다이렉트 URL (사용자 취소)
+        @NotBlank
+        String cancelUrl,
+
+        // 결제실패 리다이렉트 URL
+        @NotBlank
+        String failUrl
+) {
+    public static KakaoPayReadyReq of(
+            String orderId,
+            String userId,
+            String itemName,
+            Integer quantity,
+            Integer totalAmount,
+            Integer taxFreeAmount,
+            String approvalUrl,
+            String cancelUrl,
+            String failUrl
+    ) {
+        return new KakaoPayReadyReq(orderId, userId, itemName, quantity,
+                totalAmount, taxFreeAmount,
+                approvalUrl, cancelUrl, failUrl);
+    }
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyReq.java
@@ -1,31 +1,23 @@
 package insty.payment.kakaopay.dto;
 
+// 외부 의존성 없이 수동 검증/기본값 적용하는 Ready 요청 DTO
 public record KakaoPayReadyReq(
-
         // 파트너 주문번호
         String orderId,
-
         // 파트너 사용자 식별자
         String userId,
-
         // 상품명
         String itemName,
-
-        // 수량
-        Integer quantity,
-
-        // 총 결제금액
-        Integer totalAmount,
-
-        // 비과세 금액
-        Integer taxFreeAmount,
-
+        // 수량 (양수)
+        int quantity,
+        // 총 결제금액 (양수)
+        int totalAmount,
+        // 비과세 금액 (0 이상)
+        int taxFreeAmount,
         // 결제성공 리다이렉트 URL
         String approvalUrl,
-
         // 결제취소 리다이렉트 URL (사용자 취소)
         String cancelUrl,
-
         // 결제실패 리다이렉트 URL
         String failUrl
 ) {
@@ -40,8 +32,51 @@ public record KakaoPayReadyReq(
             String cancelUrl,
             String failUrl
     ) {
-        return new KakaoPayReadyReq(orderId, userId, itemName, quantity,
-                totalAmount, taxFreeAmount,
-                approvalUrl, cancelUrl, failUrl);
+        String normalizedOrderId   = requireNotBlank(orderId,   "orderId");
+        String normalizedUserId    = requireNotBlank(userId,    "userId");
+        String normalizedItemName  = requireNotBlank(itemName,  "itemName");
+        String normalizedApprovalUrl = requireNotBlank(approvalUrl, "approvalUrl");
+        String normalizedCancelUrl   = requireNotBlank(cancelUrl,   "cancelUrl");
+        String normalizedFailUrl     = requireNotBlank(failUrl,     "failUrl");
+
+        int normalizedQuantity   = requirePositive(quantity,    "quantity");
+        int normalizedTotalAmount = requirePositive(totalAmount, "totalAmount");
+        int normalizedTaxFreeAmount = normalizeNonNegative(taxFreeAmount);
+
+        return new KakaoPayReadyReq(
+                normalizedOrderId,
+                normalizedUserId,
+                normalizedItemName,
+                normalizedQuantity,
+                normalizedTotalAmount,
+                normalizedTaxFreeAmount,
+                normalizedApprovalUrl,
+                normalizedCancelUrl,
+                normalizedFailUrl
+        );
+    }
+
+    // 외부 의존성을 가져올 수 없기에, 내부 메서드로 처리
+
+    private static String requireNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static int requirePositive(Integer value, String fieldName) {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException(fieldName + " must be positive");
+        }
+        return value;
+    }
+
+    private static int normalizeNonNegative(Integer value) {
+        if (value == null) return 0;
+        if (value < 0) {
+            throw new IllegalArgumentException("taxFreeAmount must be >= 0");
+        }
+        return value;
     }
 }

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyRes.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyRes.java
@@ -1,0 +1,28 @@
+package insty.payment.kakaopay.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KakaoPayReadyRes(
+
+        // 카카오페이 결제 고유 id
+        String tid,
+
+        // PC 리다이렉트 URL
+        String redirectPcUrl,
+
+        // 모바일 리다이렉트 URL
+        String redirectMobileUrl,
+
+        // 앱 리다이렉트 URL
+        String redirectAppUrl
+) {
+    public static KakaoPayReadyRes of(
+            String tid,
+            String redirectPcUrl,
+            String redirectMobileUrl,
+            String redirectAppUrl
+    ) {
+        return new KakaoPayReadyRes(tid, redirectPcUrl, redirectMobileUrl, redirectAppUrl);
+    }
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyRes.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/dto/KakaoPayReadyRes.java
@@ -1,8 +1,5 @@
 package insty.payment.kakaopay.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record KakaoPayReadyRes(
 
         // 카카오페이 결제 고유 id

--- a/insty-external/src/main/java/insty/payment/kakaopay/properties/KakaoPayProperties.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/properties/KakaoPayProperties.java
@@ -1,0 +1,43 @@
+package insty.payment.kakaopay.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakaopay")
+public record KakaoPayProperties(
+        // 카카오페이 API 기본 호스트 (예: https://open-api.kakaopay.com)
+        String host,
+
+        // 카카오페이 시크릿 키
+        String secretKey,
+
+        // 가맹점 코드 (테스트 CID/실거래 CID 분리)
+        String cid,
+
+        // 온라인 결제 API 엔드포인트 경로 모음
+        OnlineEndpoints online,
+
+        // HTTP 연결/응답 타임아웃
+        Timeout timeout
+) {
+    public record OnlineEndpoints(
+            // 결제 준비 API 경로
+            String readyPath,
+
+            // 결제 승인 API 경로
+            String approvePath,
+
+            // 주문 조회 API 경로
+            String orderPath,
+
+            // 결제 취소 API 경로
+            String cancelPath
+    ) {}
+
+    public record Timeout(
+            // 연결 타임아웃 (ms)
+            Integer connectMillis,
+
+            // 응답 타임아웃 (ms)
+            Integer readMillis
+    ) {}
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/service/KakaoPayExternalService.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/service/KakaoPayExternalService.java
@@ -1,0 +1,113 @@
+package insty.payment.kakaopay.service;
+
+import insty.payment.kakaopay.dto.KakaoPayApproveDto;
+import insty.payment.kakaopay.dto.KakaoPayApproveReq;
+import insty.payment.kakaopay.dto.KakaoPayApproveRes;
+import insty.payment.kakaopay.dto.KakaoPayReadyDto;
+import insty.payment.kakaopay.dto.KakaoPayReadyReq;
+import insty.payment.kakaopay.dto.KakaoPayReadyRes;
+import insty.payment.kakaopay.properties.KakaoPayProperties;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoPayExternalService {
+
+    // 카카오 API 폼 파라미터 키
+    private static final String KEY_CID = "cid";
+    private static final String KEY_PARTNER_ORDER_ID = "partner_order_id";
+    private static final String KEY_PARTNER_USER_ID  = "partner_user_id";
+    private static final String KEY_ITEM_NAME = "item_name";
+    private static final String KEY_QUANTITY = "quantity";
+    private static final String KEY_TOTAL_AMOUNT = "total_amount";
+    private static final String KEY_TAX_FREE_AMOUNT = "tax_free_amount";
+    private static final String KEY_APPROVAL_URL = "approval_url";
+    private static final String KEY_CANCEL_URL   = "cancel_url";
+    private static final String KEY_FAIL_URL     = "fail_url";
+    private static final String KEY_TID = "tid";
+    private static final String KEY_PG_TOKEN = "pg_token";
+
+    // 외부 설정 값 (host/secretKey/cid, endpoint path 등)
+    private final KakaoPayProperties kakaoPayProperties;
+
+    // 카카오페이 전용 RestClient (Config에서 생성된 Bean, 단 하나 존재)
+    private final RestClient restClient;
+
+    // 결제 준비 호출
+    public KakaoPayReadyRes requestReady(KakaoPayReadyReq request) {
+
+        // 카카오 규격 form-data 구성
+        MultiValueMap<String, String> readyFormData = buildReadyForm(request);
+
+        // Ready API 호출 → 내부 원문 DTO로 수신
+        KakaoPayReadyDto rawReady = restClient.post()
+                .uri(kakaoPayProperties.online().readyPath())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(readyFormData)
+                .retrieve()
+                .body(KakaoPayReadyDto.class);
+
+        // 내부 표준 응답 DTO로 변환 (PC/모바일/앱 URL 모두 제공)
+        KakaoPayReadyDto nonNullRaw = Objects.requireNonNull(rawReady);
+        return KakaoPayReadyRes.of(
+                nonNullRaw.tid(),
+                nonNullRaw.nextRedirectPcUrl(),
+                nonNullRaw.nextRedirectMobileUrl(),
+                nonNullRaw.nextRedirectAppUrl()
+        );
+    }
+
+    // 결제 승인 호출
+    public KakaoPayApproveRes requestApprove(KakaoPayApproveReq request) {
+
+        // 카카오 규격 form-data 구성
+        MultiValueMap<String, String> approveFormData = buildApproveForm(request);
+
+        // Approve API 호출 → 내부 원문 DTO로 수신
+        KakaoPayApproveDto rawApprove = restClient.post()
+                .uri(kakaoPayProperties.online().approvePath())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(approveFormData)
+                .retrieve()
+                .body(KakaoPayApproveDto.class);
+
+        // 내부 표준 응답 DTO로 변환
+        KakaoPayApproveDto nonNullRaw = Objects.requireNonNull(rawApprove);
+        return KakaoPayApproveRes.of(nonNullRaw.aid(), nonNullRaw.approvedAt());
+    }
+
+    // Ready용 form-data 생성
+    private MultiValueMap<String, String> buildReadyForm(KakaoPayReadyReq request) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add(KEY_CID, kakaoPayProperties.cid());
+        formData.add(KEY_PARTNER_ORDER_ID, request.orderId());
+        formData.add(KEY_PARTNER_USER_ID,  request.userId());
+        formData.add(KEY_ITEM_NAME, request.itemName());
+        formData.add(KEY_QUANTITY, String.valueOf(request.quantity()));
+        formData.add(KEY_TOTAL_AMOUNT, String.valueOf(request.totalAmount()));
+        formData.add(KEY_TAX_FREE_AMOUNT, String.valueOf(request.taxFreeAmount()));
+        formData.add(KEY_APPROVAL_URL, request.approvalUrl());
+        formData.add(KEY_CANCEL_URL,   request.cancelUrl());
+        formData.add(KEY_FAIL_URL,     request.failUrl());
+        return formData;
+    }
+
+    // Approve용 form-data 생성
+    private MultiValueMap<String, String> buildApproveForm(KakaoPayApproveReq request) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add(KEY_CID, kakaoPayProperties.cid());
+        formData.add(KEY_TID, request.tid());
+        formData.add(KEY_PARTNER_ORDER_ID, request.orderId());
+        formData.add(KEY_PARTNER_USER_ID,  request.userId());
+        formData.add(KEY_PG_TOKEN,         request.pgToken());
+        return formData;
+    }
+}


### PR DESCRIPTION
1. 배경
원래는 아이디, 비밀번호 찾기부터 하려고 했으나 코드를 보니 비밀번호는 이미 해시화되어있고 ID는 찾을 수 있는 전화번호 등의 정보를
따로 유저가 가지고 있지 않아서, 방법이 떠오르지 않아 일단 시간이 오래 걸릴 것 같은 결제 기능부터 일부 구현
2. 기능 구현 사항
- 외부 API 연동 준비(환경설정 + DTO 변환 + 호출 서비스) 완료
- 현재 비즈니스 도메인에 연결은 아직 하지 않은 상태
- requestReady() 호출 : 결제 시작
- requestApprove() 호출 : 결제 완료 콜백

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 카카오페이 결제 연동 추가: 결제 준비(리다이렉트 URL 제공) 및 결제 승인 처리 지원
- 설정
  - 카카오페이 설정 구조 추가 및 kakaopay.timeout.connectMillis / readMillis 지원(기본값 포함)으로 안정성 향상
  - 기본 인증 헤더 및 폼 전송 구성으로 외부 결제 호출 구성 간소화
- 기타
  - 카카오페이 요청/응답용 DTO 도입으로 데이터 전달 구조 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->