### PR TITLE
✨ Feat(mixpanel): Mixpanel에 연동할 수 있게 내부 어노테이션 생성 및 테스트

### DIFF
--- a/insty-api/build.gradle
+++ b/insty-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    implementation 'org.springframework.boot:spring-boot-starter-aop' // AOP를 통한 Log 저장(mixpanel)
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3' // JSON Mapper
 
     compileOnly 'org.projectlombok:lombok'

--- a/insty-api/src/main/java/insty/domain/user/controller/AccountController.java
+++ b/insty-api/src/main/java/insty/domain/user/controller/AccountController.java
@@ -10,6 +10,8 @@ import insty.domain.user.dto.response.UserDetailRes;
 import insty.domain.user.service.AccountService;
 import insty.global.annotation.CurrentUser;
 import insty.global.response.SuccessRes;
+import insty.trackevent.TrackEvent;
+import insty.trackevent.model.MixpanelEventType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class AccountController implements AccountControllerDocs {
     private final AccountService accountService;
 
     @PostMapping
+    @TrackEvent(eventType = MixpanelEventType.AUTH_SIGNED_UP)
     public SuccessRes<UserCreateRes> signup(@Valid @RequestBody UserCreateReq req) {
         return SuccessRes.of(accountService.signup(req));
     }

--- a/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
+++ b/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
@@ -1,0 +1,123 @@
+package insty.global.trackevent;
+
+import insty.trackevent.TrackEvent;
+import insty.trackevent.model.MixpanelEventType;
+import insty.trackevent.port.AnalyticsEventPublisher;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class UserActionTrackingAspect {
+
+    private static final String ATTR_URI_TEMPLATE_VARS = HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE;
+    private static final String PROP_MEMBER_ID = "memberId";
+    private static final String PROP_HTTP_METHOD = "httpMethod";
+    private static final String PROP_IP = "ip";
+    private static final String PROP_PATH = "path";
+
+    // external 모듈의 퍼블리셔 사용
+    private final AnalyticsEventPublisher analyticsEventPublisher;
+
+    // @TrackEvent가 붙은 메서드가 정상 리턴된 경우만 처리
+    @AfterReturning(value = "@annotation(trackEvent)", argNames = "trackEvent")
+    public void publishEventAfterSuccessfulReturn(final TrackEvent trackEvent) {
+        // 인증 주체에서 memberId 추출
+        Long authenticatedMemberId = extractAuthenticatedMemberIdFromSecurityContext();
+
+        // Controller 를 통해 호출 시에 한정해서, 요청 객체 확보
+        HttpServletRequest request = resolveCurrentHttpServletRequest();
+
+        // 이벤트 속성 구성
+        Map<String, Object> eventProperties = new HashMap<>();
+        if (authenticatedMemberId != null) {
+            eventProperties.put(PROP_MEMBER_ID, authenticatedMemberId);
+        }
+        if (request != null) {
+            if (trackEvent.includeHttpMethod()) {
+                eventProperties.put(PROP_HTTP_METHOD, request.getMethod());
+            }
+            if (trackEvent.includeRequestIp()) {
+                eventProperties.put(PROP_IP, request.getRemoteAddr());
+            }
+            eventProperties.put(PROP_PATH, request.getRequestURI());
+            eventProperties.putAll(extractPathVariablesByKeys(request, trackEvent.includePathVars()));
+        }
+
+        // 이벤트 타입 결정
+        MixpanelEventType eventType = trackEvent.eventType();
+
+        // 트랜잭션 커밋 이후 발행 보장(트랜잭션이 없으면 즉시 발행)
+        Runnable publishTask = () -> analyticsEventPublisher.publish(eventType, authenticatedMemberId, eventProperties);
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publishTask.run();
+                }
+            });
+        } else {
+            publishTask.run();
+        }
+    }
+
+    // SecurityContext 에서 memberId 추출
+    private Long extractAuthenticatedMemberIdFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return null;
+        }
+        try {
+            Object principal = authentication.getPrincipal(); // AuthenticationMember 등 프로젝트 공용 Principal 가정
+            var method = principal.getClass().getMethod("getMemberId");
+            Object value = method.invoke(principal);
+            return (value instanceof Number) ? ((Number) value).longValue() : null;
+        } catch (Exception exception) {
+            log.debug("Cannot extract memberId from principal: {}", exception.toString());
+            return null;
+        }
+    }
+
+    // 현재 요청 객체 조회
+    private HttpServletRequest resolveCurrentHttpServletRequest() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            return null;
+        }
+        return (HttpServletRequest) attributes.resolveReference(RequestAttributes.REFERENCE_REQUEST);
+    }
+
+    // 지정된 키 배열에 해당하는 PathVariable만 추출
+    private Map<String, Object> extractPathVariablesByKeys(HttpServletRequest request, String[] pathVariableKeys) {
+        Map<String, Object> result = new HashMap<>();
+        if (request == null || pathVariableKeys == null || pathVariableKeys.length == 0) {
+            return result;
+        }
+        Object attribute = request.getAttribute(ATTR_URI_TEMPLATE_VARS);
+        if (attribute instanceof Map<?, ?> map) {
+            for (String key : pathVariableKeys) {
+                Object value = map.get(key);
+                if (value != null) {
+                    result.put(key, value);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
+++ b/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
@@ -76,7 +76,13 @@ public class UserActionTrackingAspect {
 
         // 트랜잭션 커밋 이후 발행 보장(트랜잭션이 없으면 즉시 발행)
         Runnable publishTask = () -> analyticsEventPublisher.publish(eventType, authenticatedMemberId, eventProperties);
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+        // 커스텀 설정된 트랜잭션 매니저나 일부 비동기 환경에서는 실제 트랜잭션은 열려 있어도 동기화가 활성화되지 않을 수 있음
+        // 이 경우 이벤트 발행 자체가 실패하게 되므로, 동기화 여부를 함께 검사하고 비활성 시에는 즉시 실행으로 폴백하는 방어 로직
+        // TX + Sync O → 커밋 후 정확히 1회 발행
+        // TX O + Sync X → 예외 없이 즉시 발행(폴백)
+        // TX X → 즉시 발행
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {

--- a/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
+++ b/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
@@ -27,21 +27,29 @@ import java.util.Map;
 public class UserActionTrackingAspect {
 
     private static final String ATTR_URI_TEMPLATE_VARS = HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE;
+
     private static final String PROP_MEMBER_ID = "memberId";
     private static final String PROP_HTTP_METHOD = "httpMethod";
+    // Mixpanel 이벤트 지오IP 파싱용 표준 키
     private static final String PROP_IP = "ip";
     private static final String PROP_PATH = "path";
+
+    private static final String HDR_X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final String HDR_X_REAL_IP = "X-Real-IP";
+    private static final String HDR_CF_CONNECTING_IP = "CF-Connecting-IP";
+    private static final String HDR_TRUE_CLIENT_IP = "True-Client-IP";
+    private static final String HDR_FORWARDED = "Forwarded";   // RFC 7239: for=1.2.3.4;proto=https
 
     // external 모듈의 퍼블리셔 사용
     private final AnalyticsEventPublisher analyticsEventPublisher;
 
     // @TrackEvent가 붙은 메서드가 정상 리턴된 경우만 처리
     @AfterReturning(value = "@annotation(trackEvent)", argNames = "trackEvent")
-    public void publishEventAfterSuccessfulReturn(final TrackEvent trackEvent) {
+    public void publishMixpanelEvent(final TrackEvent trackEvent) {
         // 인증 주체에서 memberId 추출
-        Long authenticatedMemberId = extractAuthenticatedMemberIdFromSecurityContext();
+        Long authenticatedMemberId = extractAuthenticatedMemberId();
 
-        // Controller 를 통해 호출 시에 한정해서, 요청 객체 확보
+        // 현재 요청 객체 확보(Controller 경유 시)
         HttpServletRequest request = resolveCurrentHttpServletRequest();
 
         // 이벤트 속성 구성
@@ -54,10 +62,13 @@ public class UserActionTrackingAspect {
                 eventProperties.put(PROP_HTTP_METHOD, request.getMethod());
             }
             if (trackEvent.includeRequestIp()) {
-                eventProperties.put(PROP_IP, request.getRemoteAddr());
+                String clientIp = resolveClientIp(request);
+                if (clientIp != null && !clientIp.isBlank()) {
+                    eventProperties.put(PROP_IP, clientIp); // 여기서 $ip로 전달
+                }
             }
             eventProperties.put(PROP_PATH, request.getRequestURI());
-            eventProperties.putAll(extractPathVariablesByKeys(request, trackEvent.includePathVars()));
+            eventProperties.putAll(extractPathVariables(request, trackEvent.includePathVars()));
         }
 
         // 이벤트 타입 결정
@@ -78,13 +89,13 @@ public class UserActionTrackingAspect {
     }
 
     // SecurityContext 에서 memberId 추출
-    private Long extractAuthenticatedMemberIdFromSecurityContext() {
+    private Long extractAuthenticatedMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getPrincipal() == null) {
             return null;
         }
         try {
-            Object principal = authentication.getPrincipal(); // AuthenticationMember 등 프로젝트 공용 Principal 가정
+            Object principal = authentication.getPrincipal();
             var method = principal.getClass().getMethod("getMemberId");
             Object value = method.invoke(principal);
             return (value instanceof Number) ? ((Number) value).longValue() : null;
@@ -104,7 +115,7 @@ public class UserActionTrackingAspect {
     }
 
     // 지정된 키 배열에 해당하는 PathVariable만 추출
-    private Map<String, Object> extractPathVariablesByKeys(HttpServletRequest request, String[] pathVariableKeys) {
+    private Map<String, Object> extractPathVariables(HttpServletRequest request, String[] pathVariableKeys) {
         Map<String, Object> result = new HashMap<>();
         if (request == null || pathVariableKeys == null || pathVariableKeys.length == 0) {
             return result;
@@ -119,5 +130,92 @@ public class UserActionTrackingAspect {
             }
         }
         return result;
+    }
+
+    // 프록시 헤더 우선, 폴백 순으로 IP 결정
+    private String resolveClientIp(HttpServletRequest request) {
+        // X-Forwarded-For: "client, proxy1, proxy2" 형태 → 첫 번째가 클라이언트
+        String xff = request.getHeader(HDR_X_FORWARDED_FOR);
+        if (isNotBlank(xff)) {
+            String candidate = xff.split(",")[0].trim();
+            String ip = sanitizeIpCandidate(candidate);
+            if (isNotBlank(ip)) return ip;
+        }
+
+        // X-Real-IP
+        String realIp = request.getHeader(HDR_X_REAL_IP);
+        if (isNotBlank(realIp)) {
+            String ip = sanitizeIpCandidate(realIp);
+            if (isNotBlank(ip)) return ip;
+        }
+
+        // CDN/프록시 헤더들
+        String cfIp = request.getHeader(HDR_CF_CONNECTING_IP);
+        if (isNotBlank(cfIp)) {
+            String ip = sanitizeIpCandidate(cfIp);
+            if (isNotBlank(ip)) return ip;
+        }
+        String trueClientIp = request.getHeader(HDR_TRUE_CLIENT_IP);
+        if (isNotBlank(trueClientIp)) {
+            String ip = sanitizeIpCandidate(trueClientIp);
+            if (isNotBlank(ip)) return ip;
+        }
+
+        // RFC 7239 Forwarded: for=1.2.3.4;proto=https
+        String forwarded = request.getHeader(HDR_FORWARDED);
+        if (isNotBlank(forwarded)) {
+            String ip = extractClientIpFromForwardedHeader(forwarded);
+            if (isNotBlank(ip)) return ip;
+        }
+
+        // 폴백: RemoteAddr
+        return sanitizeIpCandidate(request.getRemoteAddr());
+    }
+
+    // Forwarded 헤더에서 for= 값 파싱
+    private String extractClientIpFromForwardedHeader(String forwardedHeaderValue) {
+        // 다중 값일 수 있으므로 세미콜론/콤마 기준 토큰화
+        // 예: "for=\"203.0.113.195:1234\";proto=https, for=70.41.3.18"
+        String lower = forwardedHeaderValue.toLowerCase();
+        int idx = lower.indexOf("for=");
+        if (idx < 0) return null;
+
+        String after = forwardedHeaderValue.substring(idx + 4).trim(); // 4 == len("for=")
+        // 토큰 끝(;, ,)까지 잘라내기
+        int semi = after.indexOf(';');
+        int comma = after.indexOf(',');
+        int end = (semi < 0) ? comma : (comma < 0 ? semi : Math.min(semi, comma));
+        String token = (end < 0) ? after : after.substring(0, end);
+        return sanitizeIpCandidate(token);
+    }
+
+    // IP 후보 문자열 정리: 양끝 따옴표/대괄호 제거, 포트 제거(IPv4:port)
+    private String sanitizeIpCandidate(String candidate) {
+        if (!isNotBlank(candidate)) return null;
+        String ip = candidate.trim();
+
+        // 양끝 따옴표 제거
+        if (ip.startsWith("\"") && ip.endsWith("\"") && ip.length() >= 2) {
+            ip = ip.substring(1, ip.length() - 1);
+        }
+
+        // IPv6 대괄호 제거: [2001:db8::1]
+        if (ip.startsWith("[") && ip.contains("]")) {
+            ip = ip.substring(1, ip.indexOf(']'));
+        }
+
+        // IPv4:port 형태에서 포트 제거
+        int lastColon = ip.lastIndexOf(':');
+        if (lastColon > -1 && ip.indexOf(':') == lastColon && ip.contains(".")) {
+            // 콜론이 하나만 있고 점이 있다 → IPv4:port로 가정
+            ip = ip.substring(0, lastColon);
+        }
+
+        // 공백/빈문자 처리
+        return isNotBlank(ip) ? ip : null;
+    }
+
+    private boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/insty-api/src/main/resources/application-dev.yml
+++ b/insty-api/src/main/resources/application-dev.yml
@@ -18,4 +18,7 @@ video:
       question: 60
 
 mixpanel:
-  token: ${MIXPANEL_TOKEN}
+  enabled: false
+  token: ""
+  verbose: false
+  strict: false

--- a/insty-api/src/main/resources/application-dev.yml
+++ b/insty-api/src/main/resources/application-dev.yml
@@ -16,8 +16,3 @@ video:
       course: 60
       answer: 60
       question: 60
-
-kakaopay:
-  timeout:
-    connectMillis: 5000
-    readMillis: 10000

--- a/insty-api/src/main/resources/application-dev.yml
+++ b/insty-api/src/main/resources/application-dev.yml
@@ -16,3 +16,6 @@ video:
       course: 60
       answer: 60
       question: 60
+
+mixpanel:
+  token: ${MIXPANEL_TOKEN}

--- a/insty-api/src/main/resources/application-test.yml
+++ b/insty-api/src/main/resources/application-test.yml
@@ -56,11 +56,6 @@ oauth:
       client_id: test
       client-secret: test
 
-kakaopay:
-  timeout:
-    connectMillis: 5000
-    readMillis: 10000
-
 app:
   health-check-path: /tmp
   domain: "domain"

--- a/insty-api/src/main/resources/application-test.yml
+++ b/insty-api/src/main/resources/application-test.yml
@@ -57,7 +57,10 @@ oauth:
       client-secret: test
 
 mixpanel:
-  token: ${MIXPANEL_TOKEN}
+  enabled: false
+  token: ""
+  verbose: false
+  strict: false
 
 app:
   health-check-path: /tmp

--- a/insty-api/src/main/resources/application-test.yml
+++ b/insty-api/src/main/resources/application-test.yml
@@ -56,6 +56,9 @@ oauth:
       client_id: test
       client-secret: test
 
+mixpanel:
+  token: ${MIXPANEL_TOKEN}
+
 app:
   health-check-path: /tmp
   domain: "domain"

--- a/insty-api/src/main/resources/application.yml
+++ b/insty-api/src/main/resources/application.yml
@@ -110,3 +110,8 @@ video:
 
 mixpanel:
   token: ${MIXPANEL_TOKEN}
+  residency: US
+  verbose: true
+  strict: true
+  enabled: true
+  timeoutMillis: 5000

--- a/insty-api/src/main/resources/application.yml
+++ b/insty-api/src/main/resources/application.yml
@@ -107,3 +107,6 @@ video:
       course: 30
       answer: 10
       question: 10
+
+mixpanel:
+  token: ${MIXPANEL_TOKEN}

--- a/insty-api/src/test/java/insty/global/trackevent/UserActionTrackingAspectTest.java
+++ b/insty-api/src/test/java/insty/global/trackevent/UserActionTrackingAspectTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,15 +31,15 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class UserActionTrackingAspectTest {
 
-    @InjectMocks
-    private UserActionTrackingAspect aspect;
-
-    @Mock
-    private AnalyticsEventPublisher analyticsEventPublisher;
+    @InjectMocks private UserActionTrackingAspect aspect;
+    @Mock private AnalyticsEventPublisher analyticsEventPublisher;
+    @Captor private ArgumentCaptor<MixpanelEventType> eventTypeCaptor;
+    @Captor private ArgumentCaptor<Long> distinctIdCaptor;
+    @Captor private ArgumentCaptor<Map<String, Object>> propertiesCaptor;
 
     @AfterEach
-    // 테스트 간 영향을 주지 않게 격리하는 용도
-    void cleanContexts() {
+    void clean() {
+        // 테스트 간 컨텍스트/트랜잭션 상태 초기화
         SecurityContextHolder.clearContext();
         RequestContextHolder.resetRequestAttributes();
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
@@ -50,41 +51,30 @@ class UserActionTrackingAspectTest {
     }
 
     @Test
-    // Controller 에서 @TrackEvent(COURSE_VIEWED) 정상 종료 시, 이벤트 1회 발행 및 memberId/httpMethod/ip/path/courseId 포함 검증
-    void trackEvent_controller() {
-        // given: 인증 주체(777) 세팅 + HTTP 요청 컨텍스트/PathVariable + TrackEvent 준비
-        setSecurityPrincipalWithMemberId(777L);
+        // 컨트롤러 경유 시 HTTP 메타데이터와 PathVariable 포함
+    void controllerIncludesHttpMeta() {
+        // given: 인증 주체/요청/PathVar 준비
+        setPrincipal(777L);
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("GET");
+        req.setRequestURI("/api/courses/123");
+        req.setRemoteAddr("203.0.113.10");
+        req.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("courseId", "123"));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+        TrackEvent ev = stub(MixpanelEventType.COURSE_VIEWED, new String[]{"courseId"}, true, true);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setMethod("GET");
-        request.setRequestURI("/api/courses/123");
-        request.setRemoteAddr("203.0.113.10");
-        request.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("courseId", "123"));
-        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        // when: 어드바이스 호출
+        aspect.publishMixpanelEvent(ev);
 
-        TrackEvent trackEvent = stubTrackEvent(
-                MixpanelEventType.COURSE_VIEWED,
-                new String[] {"courseId"},
-                true,
-                true
+        // then: 이벤트 1회 발행 및 필드 검증
+        verify(analyticsEventPublisher).publish(
+                eventTypeCaptor.capture(),
+                distinctIdCaptor.capture(),
+                propertiesCaptor.capture()
         );
-
-        // when: 어드바이스 직접 호출
-        aspect.publishEventAfterSuccessfulReturn(trackEvent);
-
-        // then: 퍼블리셔 1회 호출 및 메타데이터/PathVariable 포함값 검증
-        ArgumentCaptor<MixpanelEventType> typeCaptor = ArgumentCaptor.forClass(MixpanelEventType.class);
-        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
-
-        verify(analyticsEventPublisher, times(1))
-                .publish(typeCaptor.capture(), idCaptor.capture(), propsCaptor.capture());
-
-        assertThat(typeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_VIEWED);
-        assertThat(idCaptor.getValue()).isEqualTo(777L);
-
-        Map<String, Object> props = propsCaptor.getValue();
+        Map<String, Object> props = propertiesCaptor.getValue();
+        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_VIEWED);
+        assertThat(distinctIdCaptor.getValue()).isEqualTo(777L);
         assertThat(props.get("memberId")).isEqualTo(777L);
         assertThat(props.get("httpMethod")).isEqualTo("GET");
         assertThat(props.get("ip")).isEqualTo("203.0.113.10");
@@ -92,97 +82,126 @@ class UserActionTrackingAspectTest {
         assertThat(String.valueOf(props.get("courseId"))).isEqualTo("123");
     }
 
-    // Service 에서 @TrackEvent(COURSE_LEARNING_STARTED) 정상 종료 시, 커밋 이후에만 1회 발행되고 HTTP 메타데이터는 포함되지 않는지 검증
     @Test
-    void trackEvent_service() {
-        // given: 인증 주체(888) + 요청 컨텍스트 제거 + TrackEvent 준비 + 트랜잭션 동기화/활성 플래그 설정
-        setSecurityPrincipalWithMemberId(888L);
+        // X-Forwarded-For 헤더가 있으면 첫 번째 IP 우선 사용
+    void prefersXff() {
+        // given: XFF 헤더 포함 요청
+        setPrincipal(101L);
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("GET");
+        req.setRequestURI("/api/courses/1");
+        req.setRemoteAddr("10.0.0.5");
+        req.addHeader("X-Forwarded-For", "118.47.11.208, 203.0.113.9");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+        TrackEvent ev = stub(MixpanelEventType.COURSE_VIEWED, new String[]{}, true, true);
+
+        // when
+        aspect.publishMixpanelEvent(ev);
+
+        // then
+        verify(analyticsEventPublisher).publish(any(), any(), propertiesCaptor.capture());
+        assertThat(propertiesCaptor.getValue().get("ip")).isEqualTo("118.47.11.208");
+    }
+
+    @Test
+        // Forwarded 헤더(for=...)에서 클라이언트 IP 파싱
+    void parsesForwarded() {
+        // given: Forwarded 헤더 포함 요청
+        setPrincipal(102L);
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("GET");
+        req.setRequestURI("/api/courses/2");
+        req.setRemoteAddr("10.0.0.6");
+        req.addHeader("Forwarded", "for=\"203.0.113.195:1234\";proto=https, for=70.41.3.18");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+        TrackEvent ev = stub(MixpanelEventType.COURSE_VIEWED, new String[]{}, true, true);
+
+        // when
+        aspect.publishMixpanelEvent(ev);
+
+        // then
+        verify(analyticsEventPublisher).publish(any(), any(), propertiesCaptor.capture());
+        assertThat(propertiesCaptor.getValue().get("ip")).isEqualTo("203.0.113.195");
+    }
+
+    @Test
+        // 서비스 계층에서 트랜잭션이 있을 경우, 커밋 후 발행
+    void afterCommitInService() {
+        // given: 트랜잭션 활성화
+        setPrincipal(888L);
         RequestContextHolder.resetRequestAttributes();
-        TrackEvent trackEvent = stubTrackEvent(MixpanelEventType.COURSE_LEARNING_STARTED, new String[] {}, false, false);
+        TrackEvent ev = stub(MixpanelEventType.COURSE_LEARNING_STARTED, new String[]{}, false, false);
         TransactionSynchronizationManager.initSynchronization();
         TransactionSynchronizationManager.setActualTransactionActive(true);
 
-        // when: 어드바이스 직접 호출
-        aspect.publishEventAfterSuccessfulReturn(trackEvent);
+        // when: 커밋 전 호출
+        aspect.publishMixpanelEvent(ev);
 
-        // then: 커밋 전에는 퍼블리셔 호출 없음
+        // then: 커밋 전에는 발행 안 됨
         verify(analyticsEventPublisher, times(0)).publish(any(), any(), any());
 
-        // when: afterCommit 시그널 수동 호출(커밋 시뮬레이션)
+        // when: 커밋 시뮬레이션
         List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
         syncs.forEach(TransactionSynchronization::afterCommit);
         TransactionSynchronizationManager.clearSynchronization();
         TransactionSynchronizationManager.setActualTransactionActive(false);
 
-        // then: 커밋 후 1회 호출 및 memberId만 포함(HTTP 메타데이터 없음)
-        ArgumentCaptor<MixpanelEventType> typeCaptor = ArgumentCaptor.forClass(MixpanelEventType.class);
-        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
-
-        verify(analyticsEventPublisher, times(1))
-                .publish(typeCaptor.capture(), idCaptor.capture(), propsCaptor.capture());
-
-        assertThat(typeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_LEARNING_STARTED);
-        assertThat(idCaptor.getValue()).isEqualTo(888L);
-
-        Map<String, Object> props = propsCaptor.getValue();
+        // then: 커밋 후 1회 발행 + HTTP 메타 없음
+        verify(analyticsEventPublisher).publish(
+                eventTypeCaptor.capture(),
+                distinctIdCaptor.capture(),
+                propertiesCaptor.capture()
+        );
+        Map<String, Object> props = propertiesCaptor.getValue();
+        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_LEARNING_STARTED);
+        assertThat(distinctIdCaptor.getValue()).isEqualTo(888L);
         assertThat(props.get("memberId")).isEqualTo(888L);
         assertThat(props.containsKey("httpMethod")).isFalse();
         assertThat(props.containsKey("path")).isFalse();
         assertThat(props.containsKey("ip")).isFalse();
     }
 
-    // 트랜잭션이 없을 때 @TrackEvent(AUTH_LOGGED_IN) 정상 종료 시, 이벤트가 즉시 1회 발행되고 memberId가 포함되는지 검증
     @Test
-    void trackEvent_noTransaction() {
-        // given: 인증 주체(999) 세팅 + 요청 컨텍스트 제거 + TrackEvent 준비
-        setSecurityPrincipalWithMemberId(999L);
+        // 트랜잭션 없음: 즉시 발행
+    void immediateNoTx() {
+        // given: 트랜잭션/요청컨텍스트 없음
+        setPrincipal(999L);
         RequestContextHolder.resetRequestAttributes();
-        TrackEvent trackEvent = stubTrackEvent(MixpanelEventType.AUTH_LOGGED_IN, new String[] {}, false, false);
+        TrackEvent ev = stub(MixpanelEventType.AUTH_LOGGED_IN, new String[]{}, false, false);
 
-        // when: 어드바이스 직접 호출
-        aspect.publishEventAfterSuccessfulReturn(trackEvent);
+        // when
+        aspect.publishMixpanelEvent(ev);
 
-        // then: 퍼블리셔 1회 호출 및 memberId 포함 검증
-        ArgumentCaptor<MixpanelEventType> typeCaptor = ArgumentCaptor.forClass(MixpanelEventType.class);
-        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
-
-        verify(analyticsEventPublisher, times(1))
-                .publish(typeCaptor.capture(), idCaptor.capture(), propsCaptor.capture());
-
-        assertThat(typeCaptor.getValue()).isEqualTo(MixpanelEventType.AUTH_LOGGED_IN);
-        assertThat(idCaptor.getValue()).isEqualTo(999L);
-        assertThat(propsCaptor.getValue().get("memberId")).isEqualTo(999L);
+        // then
+        verify(analyticsEventPublisher).publish(
+                eventTypeCaptor.capture(),
+                distinctIdCaptor.capture(),
+                propertiesCaptor.capture()
+        );
+        Map<String, Object> props = propertiesCaptor.getValue();
+        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.AUTH_LOGGED_IN);
+        assertThat(distinctIdCaptor.getValue()).isEqualTo(999L);
+        assertThat(props.get("memberId")).isEqualTo(999L);
     }
 
-    // 테스트용 Principal 인터페이스(Aspect가 리플렉션으로 호출하는 getMemberId 제공)
+    // 간단한 Principal 스텁(Aspect가 getMemberId 리플렉션 호출)
     private interface HasMemberId { Long getMemberId(); }
 
-    // SecurityContext에 memberId를 가진 Principal 목 객체를 주입
-    private void setSecurityPrincipalWithMemberId(Long memberId) {
-        HasMemberId principal = mock(HasMemberId.class);
-        when(principal.getMemberId()).thenReturn(memberId);
-
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(principal);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+    private void setPrincipal(Long memberId) {
+        HasMemberId p = mock(HasMemberId.class);
+        when(p.getMemberId()).thenReturn(memberId);
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(p);
+        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
-    // @TrackEvent 어노테이션 값을 대신할 익명 구현체를 생성하여 스텁으로 제공
-    private TrackEvent stubTrackEvent(
-            MixpanelEventType eventType,
-            String[] includePathVars,
-            boolean includeIp,
-            boolean includeHttpMethod
-    ) {
+    // @TrackEvent 익명 구현체 스텁
+    private TrackEvent stub(MixpanelEventType type, String[] pathVars, boolean includeIp, boolean includeMethod) {
         return new TrackEvent() {
-            @Override public MixpanelEventType eventType() { return eventType; }
-            @Override public String[] includePathVars() { return includePathVars; }
+            @Override public MixpanelEventType eventType() { return type; }
+            @Override public String[] includePathVars() { return pathVars; }
             @Override public boolean includeRequestIp() { return includeIp; }
-            @Override public boolean includeHttpMethod() { return includeHttpMethod; }
+            @Override public boolean includeHttpMethod() { return includeMethod; }
             @Override public Class<? extends Annotation> annotationType() { return TrackEvent.class; }
         };
     }

--- a/insty-api/src/test/java/insty/global/trackevent/UserActionTrackingAspectTest.java
+++ b/insty-api/src/test/java/insty/global/trackevent/UserActionTrackingAspectTest.java
@@ -1,0 +1,189 @@
+package insty.global.trackevent;
+
+import insty.trackevent.TrackEvent;
+import insty.trackevent.model.MixpanelEventType;
+import insty.trackevent.port.AnalyticsEventPublisher;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class UserActionTrackingAspectTest {
+
+    @InjectMocks
+    private UserActionTrackingAspect aspect;
+
+    @Mock
+    private AnalyticsEventPublisher analyticsEventPublisher;
+
+    @AfterEach
+    // 테스트 간 영향을 주지 않게 격리하는 용도
+    void cleanContexts() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.setActualTransactionActive(false);
+        }
+    }
+
+    @Test
+    // Controller 에서 @TrackEvent(COURSE_VIEWED) 정상 종료 시, 이벤트 1회 발행 및 memberId/httpMethod/ip/path/courseId 포함 검증
+    void trackEvent_controller() {
+        // given: 인증 주체(777) 세팅 + HTTP 요청 컨텍스트/PathVariable + TrackEvent 준비
+        setSecurityPrincipalWithMemberId(777L);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setRequestURI("/api/courses/123");
+        request.setRemoteAddr("203.0.113.10");
+        request.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("courseId", "123"));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        TrackEvent trackEvent = stubTrackEvent(
+                MixpanelEventType.COURSE_VIEWED,
+                new String[] {"courseId"},
+                true,
+                true
+        );
+
+        // when: 어드바이스 직접 호출
+        aspect.publishEventAfterSuccessfulReturn(trackEvent);
+
+        // then: 퍼블리셔 1회 호출 및 메타데이터/PathVariable 포함값 검증
+        ArgumentCaptor<MixpanelEventType> typeCaptor = ArgumentCaptor.forClass(MixpanelEventType.class);
+        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(analyticsEventPublisher, times(1))
+                .publish(typeCaptor.capture(), idCaptor.capture(), propsCaptor.capture());
+
+        assertThat(typeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_VIEWED);
+        assertThat(idCaptor.getValue()).isEqualTo(777L);
+
+        Map<String, Object> props = propsCaptor.getValue();
+        assertThat(props.get("memberId")).isEqualTo(777L);
+        assertThat(props.get("httpMethod")).isEqualTo("GET");
+        assertThat(props.get("ip")).isEqualTo("203.0.113.10");
+        assertThat(props.get("path")).isEqualTo("/api/courses/123");
+        assertThat(String.valueOf(props.get("courseId"))).isEqualTo("123");
+    }
+
+    // Service 에서 @TrackEvent(COURSE_LEARNING_STARTED) 정상 종료 시, 커밋 이후에만 1회 발행되고 HTTP 메타데이터는 포함되지 않는지 검증
+    @Test
+    void trackEvent_service() {
+        // given: 인증 주체(888) + 요청 컨텍스트 제거 + TrackEvent 준비 + 트랜잭션 동기화/활성 플래그 설정
+        setSecurityPrincipalWithMemberId(888L);
+        RequestContextHolder.resetRequestAttributes();
+        TrackEvent trackEvent = stubTrackEvent(MixpanelEventType.COURSE_LEARNING_STARTED, new String[] {}, false, false);
+        TransactionSynchronizationManager.initSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+
+        // when: 어드바이스 직접 호출
+        aspect.publishEventAfterSuccessfulReturn(trackEvent);
+
+        // then: 커밋 전에는 퍼블리셔 호출 없음
+        verify(analyticsEventPublisher, times(0)).publish(any(), any(), any());
+
+        // when: afterCommit 시그널 수동 호출(커밋 시뮬레이션)
+        List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
+        syncs.forEach(TransactionSynchronization::afterCommit);
+        TransactionSynchronizationManager.clearSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+
+        // then: 커밋 후 1회 호출 및 memberId만 포함(HTTP 메타데이터 없음)
+        ArgumentCaptor<MixpanelEventType> typeCaptor = ArgumentCaptor.forClass(MixpanelEventType.class);
+        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(analyticsEventPublisher, times(1))
+                .publish(typeCaptor.capture(), idCaptor.capture(), propsCaptor.capture());
+
+        assertThat(typeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_LEARNING_STARTED);
+        assertThat(idCaptor.getValue()).isEqualTo(888L);
+
+        Map<String, Object> props = propsCaptor.getValue();
+        assertThat(props.get("memberId")).isEqualTo(888L);
+        assertThat(props.containsKey("httpMethod")).isFalse();
+        assertThat(props.containsKey("path")).isFalse();
+        assertThat(props.containsKey("ip")).isFalse();
+    }
+
+    // 트랜잭션이 없을 때 @TrackEvent(AUTH_LOGGED_IN) 정상 종료 시, 이벤트가 즉시 1회 발행되고 memberId가 포함되는지 검증
+    @Test
+    void trackEvent_noTransaction() {
+        // given: 인증 주체(999) 세팅 + 요청 컨텍스트 제거 + TrackEvent 준비
+        setSecurityPrincipalWithMemberId(999L);
+        RequestContextHolder.resetRequestAttributes();
+        TrackEvent trackEvent = stubTrackEvent(MixpanelEventType.AUTH_LOGGED_IN, new String[] {}, false, false);
+
+        // when: 어드바이스 직접 호출
+        aspect.publishEventAfterSuccessfulReturn(trackEvent);
+
+        // then: 퍼블리셔 1회 호출 및 memberId 포함 검증
+        ArgumentCaptor<MixpanelEventType> typeCaptor = ArgumentCaptor.forClass(MixpanelEventType.class);
+        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(analyticsEventPublisher, times(1))
+                .publish(typeCaptor.capture(), idCaptor.capture(), propsCaptor.capture());
+
+        assertThat(typeCaptor.getValue()).isEqualTo(MixpanelEventType.AUTH_LOGGED_IN);
+        assertThat(idCaptor.getValue()).isEqualTo(999L);
+        assertThat(propsCaptor.getValue().get("memberId")).isEqualTo(999L);
+    }
+
+    // 테스트용 Principal 인터페이스(Aspect가 리플렉션으로 호출하는 getMemberId 제공)
+    private interface HasMemberId { Long getMemberId(); }
+
+    // SecurityContext에 memberId를 가진 Principal 목 객체를 주입
+    private void setSecurityPrincipalWithMemberId(Long memberId) {
+        HasMemberId principal = mock(HasMemberId.class);
+        when(principal.getMemberId()).thenReturn(memberId);
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(principal);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    // @TrackEvent 어노테이션 값을 대신할 익명 구현체를 생성하여 스텁으로 제공
+    private TrackEvent stubTrackEvent(
+            MixpanelEventType eventType,
+            String[] includePathVars,
+            boolean includeIp,
+            boolean includeHttpMethod
+    ) {
+        return new TrackEvent() {
+            @Override public MixpanelEventType eventType() { return eventType; }
+            @Override public String[] includePathVars() { return includePathVars; }
+            @Override public boolean includeRequestIp() { return includeIp; }
+            @Override public boolean includeHttpMethod() { return includeHttpMethod; }
+            @Override public Class<? extends Annotation> annotationType() { return TrackEvent.class; }
+        };
+    }
+}

--- a/insty-common/src/main/java/insty/trackevent/TrackEvent.java
+++ b/insty-common/src/main/java/insty/trackevent/TrackEvent.java
@@ -1,0 +1,23 @@
+package insty.trackevent;
+
+import insty.trackevent.model.MixpanelEventType;
+import java.lang.annotation.*;
+
+// 특정 메서드가 정상 종료되었을 때 이벤트 트래킹을 트리거하는 어노테이션
+@Target(ElementType.METHOD)               // 메서드에만 사용
+@Retention(RetentionPolicy.RUNTIME)       // 런타임까지 유지(AOP 인식)
+@Documented                               // Javadoc 문서에 포함
+public @interface TrackEvent {
+
+    // 발행할 이벤트 종류(필수)
+    MixpanelEventType eventType();
+
+    // 이벤트 속성에 포함할 PathVariable 키 배열
+    String[] includePathVars() default {};
+
+    // 요청 IP를 이벤트 속성에 포함할지 여부
+    boolean includeRequestIp() default true;
+
+    // HTTP 메서드(GET/POST 등) 포함 여부
+    boolean includeHttpMethod() default true;
+}

--- a/insty-common/src/main/java/insty/trackevent/model/MixpanelEventType.java
+++ b/insty-common/src/main/java/insty/trackevent/model/MixpanelEventType.java
@@ -1,0 +1,19 @@
+package insty.trackevent.model;
+
+// 이벤트 네이밍: <DOMAIN>_<ACTION>_<RESULT/STATE>
+public enum MixpanelEventType {
+
+    // USER
+    AUTH_SIGNED_UP,          // 회원가입 완료
+    AUTH_LOGGED_IN,          // 로그인 성공
+    AUTH_EMAIL_VERIFIED,     // 이메일 인증 완료
+
+    // COURSE
+    COURSE_VIEWED,           // 강의 상세 진입
+    COURSE_LEARNING_STARTED, // 강의 수강 시작
+
+    // COMMUNITY
+    COMMUNITY_QUESTION_CREATED, // 질문 작성
+    COMMUNITY_ANSWER_CREATED,   // 답변 작성
+    COMMUNITY_ANSWER_ACCEPTED   // 답변 채택
+}

--- a/insty-common/src/main/java/insty/trackevent/port/AnalyticsEventPublisher.java
+++ b/insty-common/src/main/java/insty/trackevent/port/AnalyticsEventPublisher.java
@@ -1,0 +1,9 @@
+package insty.trackevent.port;
+
+import insty.trackevent.model.MixpanelEventType;
+import java.util.Map;
+
+// 외부로 보내는 전용 포트를 통해, 분석 이벤트 발행을 추상화하는 목적
+public interface AnalyticsEventPublisher {
+    void publish(MixpanelEventType eventType, Long distinctId, Map<String, Object> properties);
+}

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -76,15 +76,23 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
         // 비동기 전송 (timeout + retry(backoff), fire-and-forget)
         sendAsyncRequest(formData)
                 .doOnNext(responseBody -> {
+                    // 성공 로그: INFO는 이벤트명만, DEBUG는 응답 전문
                     if (log.isDebugEnabled()) {
                         log.debug("[Mixpanel] response={}", responseBody); // ex) {"status":1,...}
                     } else {
                         log.info("[Mixpanel] published event={}", eventType);
                     }
                 })
-                .doOnError(error ->
-                        log.warn("[Mixpanel] publish fail event={} distinct_id={} error={}",
-                                eventType, normalizedProperties.get(PROPERTY_DISTINCT_ID), error.toString()))
+                .doOnError(error -> {
+                    // 실패 로그: WARN에서는 식별자 제거, DEBUG에서만 distinct_id 출력
+                    if (log.isDebugEnabled()) {
+                        log.debug("[Mixpanel] publish fail event={} distinct_id={} error={}",
+                                eventType, normalizedProperties.get(PROPERTY_DISTINCT_ID), error.toString());
+                    } else {
+                        log.warn("[Mixpanel] publish fail event={} error={}",
+                                eventType, error.toString());
+                    }
+                })
                 .onErrorResume(error -> Mono.empty()) // 실패해도 업무 흐름 영향 X
                 .subscribe(); // fire-and-forget
     }

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -41,8 +41,7 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
     private final Boolean strictValidationEnabled;
     private final Boolean trackingEnabled;
     private final Integer requestTimeoutMillis;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public void publish(final MixpanelEventType eventType,

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -10,7 +10,6 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
@@ -22,8 +21,10 @@ import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 @Slf4j
-@RequiredArgsConstructor
-public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
+public record MixpanelEventPublisherAdapter(WebClient webClient, String projectToken, String mixpanelHost,
+                                            Boolean verboseResponseEnabled, Boolean strictValidationEnabled,
+                                            Boolean trackingEnabled, Integer requestTimeoutMillis,
+                                            ObjectMapper objectMapper) implements AnalyticsEventPublisher {
 
     private static final String TRACK_PATH = "/track";
     private static final String PROPERTY_TOKEN = "token";
@@ -33,16 +34,6 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
 
     private static final String QUERY_VERBOSE_ON = "1";
     private static final String QUERY_STRICT_ON = "1";
-
-    private final WebClient webClient;
-    private final String projectToken;
-    private final String mixpanelHost;        // ex) api.mixpanel.com | api-eu.mixpanel.com
-    private final Boolean verboseResponseEnabled;
-    private final Boolean strictValidationEnabled;
-    private final Boolean trackingEnabled;
-    private final Integer requestTimeoutMillis;
-
-    private final ObjectMapper objectMapper;
 
     @Override
     public void publish(final MixpanelEventType eventType,
@@ -111,7 +102,9 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
         final Map<String, Object> eventProperties = new LinkedHashMap<>();
         if (rawEventProperties != null) {
             rawEventProperties.forEach((key, value) -> {
-                if (value != null) eventProperties.put(key, value);
+                if (value != null) {
+                    eventProperties.put(key, value);
+                }
             });
         }
         eventProperties.put(PROPERTY_TOKEN, projectToken);
@@ -152,7 +145,7 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
                         .host(mixpanelHost)
                         .path(TRACK_PATH)
                         .queryParam("verbose", Boolean.TRUE.equals(verboseResponseEnabled) ? QUERY_VERBOSE_ON : null)
-                        .queryParam("strict",  Boolean.TRUE.equals(strictValidationEnabled) ? QUERY_STRICT_ON : null)
+                        .queryParam("strict", Boolean.TRUE.equals(strictValidationEnabled) ? QUERY_STRICT_ON : null)
                         .build())
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(formData))

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -41,6 +41,7 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
     private final Boolean strictValidationEnabled;
     private final Boolean trackingEnabled;
     private final Integer requestTimeoutMillis;
+
     private final ObjectMapper objectMapper;
 
     @Override

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -1,60 +1,175 @@
 package insty.mixpanel.adapter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import insty.trackevent.model.MixpanelEventType;
 import insty.trackevent.port.AnalyticsEventPublisher;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.HashMap;
-import java.util.Map;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 @Slf4j
 @RequiredArgsConstructor
 public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
 
-    // Mixpanel 이벤트 수집 엔드포인트
-    private static final String MIXPANEL_TRACK_ENDPOINT = "https://api.mixpanel.com/track";
+    private static final String TRACK_PATH = "/track";
+    private static final String PROPERTY_TOKEN = "token";
+    private static final String PROPERTY_DISTINCT_ID = "distinct_id";
+    private static final String PROPERTY_TIME = "time";
+    private static final String PROPERTY_INSERT_ID = "$insert_id";
+
+    private static final String QUERY_VERBOSE_ON = "1";
+    private static final String QUERY_STRICT_ON = "1";
 
     private final WebClient webClient;
-
-    // Mixpanel 프로젝트 토큰
     private final String projectToken;
+    private final String mixpanelHost;        // ex) api.mixpanel.com | api-eu.mixpanel.com
+    private final Boolean verboseResponseEnabled;
+    private final Boolean strictValidationEnabled;
+    private final Boolean trackingEnabled;
+    private final Integer requestTimeoutMillis;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public void publish(MixpanelEventType eventType, Long distinctId, Map<String, Object> properties) {
+    public void publish(final MixpanelEventType eventType,
+                        final Long distinctId,
+                        final Map<String, Object> rawEventProperties) {
 
-        Map<String, Object> body = buildMixpanelTrackRequestBody(eventType, distinctId, properties);
+        // 설정값 검증
+        // 전역 스위치(trackingEnabled), 프로젝트 토큰(projectToken), 호스트(mixpanelHost) 등 유효성 확인
+        verifyConfiguration();
 
-        // 비동기 전송
-        // Fire and Forget 처리
-        webClient.post()
-                .uri(MIXPANEL_TRACK_ENDPOINT)
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(body)
-                .retrieve()
-                .toBodilessEntity()
-                .doOnError(exception -> log.warn("Failed to publish Mixpanel event: {}, error={}", eventType, exception.toString()))
-                .onErrorComplete()
+        // 이벤트 속성 표준화
+        // 요청으로 넘어온 rawEventProperties를 기반으로 null 값 제거
+        // token, distinct_id, time(epoch sec), $insert_id(중복 방지용) 보강
+        final Map<String, Object> normalizedProperties =
+                buildProperties(distinctId, rawEventProperties);
+
+        // 이벤트 JSON 직렬화
+        // {"event":"...", "properties":{...}} 형태로 직렬화
+        final String eventJson = serializeEventToJson(eventType, normalizedProperties);
+
+        // 전송 바디 생성 (Mixpanel 표준 포맷)
+        // JSON → base64 인코딩 → application/x-www-form-urlencoded 의 data=<base64(JSON)>
+        final MultiValueMap<String, String> formData =
+                buildFormDataFromBase64Json(eventJson);
+
+        // 사전 로깅
+        // 요청 시작 로깅 (token은 마스킹)
+        log.info("[Mixpanel] publish start event={} distinct_id={} properties(maskedToken)={}",
+                eventType, normalizedProperties.get(PROPERTY_DISTINCT_ID),
+                buildMaskedTokenProperties(normalizedProperties));
+
+        // 비동기 전송 (fire-and-forget)
+        // sendAsyncRequest(formData): WebClient POST /track 호출
+        // verbose/strict 쿼리 파라미터 반영, timeout + retry(backoff) 포함
+        // 성공 시: 응답 바디(예: {"status":1,...}) INFO 로깅
+        // 실패 시: WARN 로깅 후 onErrorResume으로 스트림 종료(업무 흐름 영향 X)
+        // subscribe() 호출로 실제 요청 트리거
+        sendAsyncRequest(formData)
+                .doOnNext(responseBody ->
+                        log.info("[Mixpanel] response={}", responseBody)) // 기대: {"status":1,...}
+                .doOnError(error ->
+                        log.warn("[Mixpanel] publish fail event={} distinct_id={} error={}",
+                                eventType, normalizedProperties.get(PROPERTY_DISTINCT_ID), error.toString()))
+                .onErrorResume(error -> Mono.empty()) // 실패해도 업무 흐름 영향 X
                 .subscribe();
     }
 
-    private Map<String, Object> buildMixpanelTrackRequestBody(MixpanelEventType eventType, Long distinctId,
-                                                              Map<String, Object> properties) {
-        if (projectToken == null || projectToken.isBlank()) {
-            throw new IllegalArgumentException("Mixpanel token is missing");
+    // 설정값 검증
+    private void verifyConfiguration() {
+        Assert.isTrue(Boolean.TRUE.equals(trackingEnabled), "Mixpanel disabled");
+        Assert.hasText(projectToken, "Mixpanel token must not be blank");
+        Assert.hasText(mixpanelHost, "Mixpanel host must not be blank");
+        Assert.isTrue(requestTimeoutMillis != null && requestTimeoutMillis > 0, "Timeout must be positive");
+    }
+
+    // distinctId/토큰/시간/$insert_id 포함하여 properties 생성
+    private Map<String, Object> buildProperties(final Long distinctId,
+                                                final Map<String, Object> rawEventProperties) {
+        final Map<String, Object> eventProperties = new LinkedHashMap<>();
+
+        if (rawEventProperties != null) {
+            rawEventProperties.forEach((key, value) -> {
+                if (value != null) eventProperties.put(key, value);
+            });
         }
 
-        // 기존 속성에 token, distinct_id를 추가해 Mixpanel properties 구성
-        Map<String, Object> props = new HashMap<>(properties);
-        props.put("token", projectToken);
-        props.put("distinct_id", distinctId);
+        eventProperties.put(PROPERTY_TOKEN, projectToken);
+        eventProperties.put(PROPERTY_DISTINCT_ID, (distinctId == null) ? "anonymous" : String.valueOf(distinctId));
+        eventProperties.putIfAbsent(PROPERTY_TIME, Instant.now().getEpochSecond());
+        eventProperties.putIfAbsent(PROPERTY_INSERT_ID, UUID.randomUUID().toString());
 
-        // 최종 body 구성
-        Map<String, Object> body = new HashMap<>();
-        body.put("event", eventType.name());
-        body.put("properties", props);
-        return body;
+        return eventProperties;
+    }
+
+    // {"event": "...", "properties": {...}} 직렬화
+    private String serializeEventToJson(final MixpanelEventType eventType,
+                                        final Map<String, Object> normalizedProperties) {
+        try {
+            final Map<String, Object> eventEnvelope = Map.of(
+                    "event", eventType.name(),
+                    "properties", normalizedProperties
+            );
+            return objectMapper.writeValueAsString(eventEnvelope);
+        } catch (Exception exception) {
+            throw new IllegalArgumentException("Failed to serialize Mixpanel event JSON", exception);
+        }
+    }
+
+    // data=<base64(JSON)> 형태의 form-urlencoded 바디 생성
+    private MultiValueMap<String, String> buildFormDataFromBase64Json(final String eventJson) {
+        final String base64EncodedData =
+                Base64.getEncoder().encodeToString(eventJson.getBytes(StandardCharsets.UTF_8));
+
+        final MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("data", base64EncodedData);
+        return formData;
+    }
+
+    // 실제 비동기 전송 (timeout + retry(backoff))
+    private Mono<String> sendAsyncRequest(final MultiValueMap<String, String> formData) {
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host(mixpanelHost)
+                        .path(TRACK_PATH)
+                        .queryParam("verbose", Boolean.TRUE.equals(verboseResponseEnabled) ? QUERY_VERBOSE_ON : null)
+                        .queryParam("strict",  Boolean.TRUE.equals(strictValidationEnabled) ? QUERY_STRICT_ON : null)
+                        .build())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(Duration.ofMillis(requestTimeoutMillis))
+                .retryWhen(
+                        Retry.backoff(2, Duration.ofMillis(300))
+                                .maxBackoff(Duration.ofSeconds(2))
+                                .jitter(0.5)
+                );
+    }
+
+    // 토큰 마스킹하여 로깅
+    private Map<String, Object> buildMaskedTokenProperties(final Map<String, Object> originalProperties) {
+        final Map<String, Object> masked = new LinkedHashMap<>(originalProperties);
+        final Object token = masked.get(PROPERTY_TOKEN);
+        if (token instanceof String tokenString && tokenString.length() > 6) {
+            masked.put(PROPERTY_TOKEN, tokenString.substring(0, 6) + "****");
+        }
+        return masked;
     }
 }

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -1,0 +1,60 @@
+package insty.mixpanel.adapter;
+
+import insty.trackevent.model.MixpanelEventType;
+import insty.trackevent.port.AnalyticsEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
+
+    // Mixpanel 이벤트 수집 엔드포인트
+    private static final String MIXPANEL_TRACK_ENDPOINT = "https://api.mixpanel.com/track";
+
+    private final WebClient webClient;
+
+    // Mixpanel 프로젝트 토큰
+    private final String projectToken;
+
+    @Override
+    public void publish(MixpanelEventType eventType, Long distinctId, Map<String, Object> properties) {
+
+        Map<String, Object> body = buildMixpanelTrackRequestBody(eventType, distinctId, properties);
+
+        // 비동기 전송
+        // Fire and Forget 처리
+        webClient.post()
+                .uri(MIXPANEL_TRACK_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .toBodilessEntity()
+                .doOnError(exception -> log.warn("Failed to publish Mixpanel event: {}, error={}", eventType, exception.toString()))
+                .onErrorComplete()
+                .subscribe();
+    }
+
+    private Map<String, Object> buildMixpanelTrackRequestBody(MixpanelEventType eventType, Long distinctId,
+                                                              Map<String, Object> properties) {
+        if (projectToken == null || projectToken.isBlank()) {
+            throw new IllegalArgumentException("Mixpanel token is missing");
+        }
+
+        // 기존 속성에 token, distinct_id를 추가해 Mixpanel properties 구성
+        Map<String, Object> props = new HashMap<>(properties);
+        props.put("token", projectToken);
+        props.put("distinct_id", distinctId);
+
+        // 최종 body 구성
+        Map<String, Object> body = new HashMap<>();
+        body.put("event", eventType.name());
+        body.put("properties", props);
+        return body;
+    }
+}

--- a/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
+++ b/insty-external/src/main/java/insty/mixpanel/adapter/MixpanelEventPublisherAdapter.java
@@ -50,44 +50,43 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
                         final Map<String, Object> rawEventProperties) {
 
         // 설정값 검증
-        // 전역 스위치(trackingEnabled), 프로젝트 토큰(projectToken), 호스트(mixpanelHost) 등 유효성 확인
         verifyConfiguration();
 
-        // 이벤트 속성 표준화
-        // 요청으로 넘어온 rawEventProperties를 기반으로 null 값 제거
-        // token, distinct_id, time(epoch sec), $insert_id(중복 방지용) 보강
+        // 이벤트 속성 표준화 (token, distinct_id, time, $insert_id 보강)
         final Map<String, Object> normalizedProperties =
                 buildProperties(distinctId, rawEventProperties);
 
-        // 이벤트 JSON 직렬화
-        // {"event":"...", "properties":{...}} 형태로 직렬화
+        // 이벤트 JSON 직렬화 ({"event": "...", "properties": {...}})
         final String eventJson = serializeEventToJson(eventType, normalizedProperties);
 
-        // 전송 바디 생성 (Mixpanel 표준 포맷)
-        // JSON → base64 인코딩 → application/x-www-form-urlencoded 의 data=<base64(JSON)>
+        // form-urlencoded data=<base64(JSON)> 바디 생성
         final MultiValueMap<String, String> formData =
-                buildFormDataFromBase64Json(eventJson);
+                buildFormData(eventJson);
 
-        // 사전 로깅
-        // 요청 시작 로깅 (token은 마스킹)
-        log.info("[Mixpanel] publish start event={} distinct_id={} properties(maskedToken)={}",
-                eventType, normalizedProperties.get(PROPERTY_DISTINCT_ID),
-                buildMaskedTokenProperties(normalizedProperties));
+        // 로깅 — INFO엔 이벤트명만, 상세는 DEBUG에서만 (PII 최소화)
+        if (log.isDebugEnabled()) {
+            log.debug("[Mixpanel] publish start event={} distinct_id={} properties(masked-token)={}",
+                    eventType,
+                    normalizedProperties.get(PROPERTY_DISTINCT_ID),
+                    buildMaskedTokenProperties(normalizedProperties));
+        } else {
+            log.info("[Mixpanel] publish start event={}", eventType);
+        }
 
-        // 비동기 전송 (fire-and-forget)
-        // sendAsyncRequest(formData): WebClient POST /track 호출
-        // verbose/strict 쿼리 파라미터 반영, timeout + retry(backoff) 포함
-        // 성공 시: 응답 바디(예: {"status":1,...}) INFO 로깅
-        // 실패 시: WARN 로깅 후 onErrorResume으로 스트림 종료(업무 흐름 영향 X)
-        // subscribe() 호출로 실제 요청 트리거
+        // 비동기 전송 (timeout + retry(backoff), fire-and-forget)
         sendAsyncRequest(formData)
-                .doOnNext(responseBody ->
-                        log.info("[Mixpanel] response={}", responseBody)) // 기대: {"status":1,...}
+                .doOnNext(responseBody -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[Mixpanel] response={}", responseBody); // ex) {"status":1,...}
+                    } else {
+                        log.info("[Mixpanel] published event={}", eventType);
+                    }
+                })
                 .doOnError(error ->
                         log.warn("[Mixpanel] publish fail event={} distinct_id={} error={}",
                                 eventType, normalizedProperties.get(PROPERTY_DISTINCT_ID), error.toString()))
                 .onErrorResume(error -> Mono.empty()) // 실패해도 업무 흐름 영향 X
-                .subscribe();
+                .subscribe(); // fire-and-forget
     }
 
     // 설정값 검증
@@ -102,18 +101,15 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
     private Map<String, Object> buildProperties(final Long distinctId,
                                                 final Map<String, Object> rawEventProperties) {
         final Map<String, Object> eventProperties = new LinkedHashMap<>();
-
         if (rawEventProperties != null) {
             rawEventProperties.forEach((key, value) -> {
                 if (value != null) eventProperties.put(key, value);
             });
         }
-
         eventProperties.put(PROPERTY_TOKEN, projectToken);
         eventProperties.put(PROPERTY_DISTINCT_ID, (distinctId == null) ? "anonymous" : String.valueOf(distinctId));
         eventProperties.putIfAbsent(PROPERTY_TIME, Instant.now().getEpochSecond());
         eventProperties.putIfAbsent(PROPERTY_INSERT_ID, UUID.randomUUID().toString());
-
         return eventProperties;
     }
 
@@ -132,10 +128,9 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
     }
 
     // data=<base64(JSON)> 형태의 form-urlencoded 바디 생성
-    private MultiValueMap<String, String> buildFormDataFromBase64Json(final String eventJson) {
+    private MultiValueMap<String, String> buildFormData(final String eventJson) {
         final String base64EncodedData =
                 Base64.getEncoder().encodeToString(eventJson.getBytes(StandardCharsets.UTF_8));
-
         final MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("data", base64EncodedData);
         return formData;
@@ -163,7 +158,7 @@ public class MixpanelEventPublisherAdapter implements AnalyticsEventPublisher {
                 );
     }
 
-    // 토큰 마스킹하여 로깅
+    // 토큰 마스킹(나머지 값은 DEBUG에서만 출력)
     private Map<String, Object> buildMaskedTokenProperties(final Map<String, Object> originalProperties) {
         final Map<String, Object> masked = new LinkedHashMap<>(originalProperties);
         final Object token = masked.get(PROPERTY_TOKEN);

--- a/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
+++ b/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
@@ -1,5 +1,6 @@
 package insty.mixpanel.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import insty.mixpanel.adapter.MixpanelEventPublisherAdapter;
 import insty.trackevent.port.AnalyticsEventPublisher;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +25,8 @@ public class MixpanelConfig {
             @Value("${mixpanel.residency}") String residency,
             @Value("${mixpanel.verbose}") Boolean verbose,
             @Value("${mixpanel.strict}") Boolean strict,
-            @Value("${mixpanel.timeoutMillis}") Integer timeoutMillis
-    ) {
+            @Value("${mixpanel.timeoutMillis}") Integer timeoutMillis,
+            ObjectMapper objectMapper) {
         // 활성화 및 토큰 체크
         if (Boolean.FALSE.equals(enabled)) {
             log.warn("[Mixpanel] disabled by config. Tracking is OFF.");
@@ -48,7 +49,8 @@ public class MixpanelConfig {
                 verbose,
                 strict,
                 enabled,
-                timeoutMillis
+                timeoutMillis,
+                objectMapper
         );
     }
 }

--- a/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
+++ b/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
@@ -13,7 +13,7 @@ public class MixpanelConfig {
     @Bean
     public AnalyticsEventPublisher analyticsEventPublisher(
             WebClient.Builder webClientBuilder,
-            @Value("${mixpanel.token:}") String mixpanelToken
+            @Value("${app.mixpanel.token:}") String mixpanelToken
     ) {
         return new MixpanelEventPublisherAdapter(webClientBuilder.build(), mixpanelToken);
     }

--- a/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
+++ b/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
@@ -2,19 +2,53 @@ package insty.mixpanel.config;
 
 import insty.mixpanel.adapter.MixpanelEventPublisherAdapter;
 import insty.trackevent.port.AnalyticsEventPublisher;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Configuration
 public class MixpanelConfig {
+
+    private static final String HOST_US = "api.mixpanel.com";
+    private static final String HOST_EU = "api-eu.mixpanel.com";
 
     @Bean
     public AnalyticsEventPublisher analyticsEventPublisher(
             WebClient.Builder webClientBuilder,
-            @Value("${app.mixpanel.token:}") String mixpanelToken
+            @Value("${mixpanel.enabled}") Boolean enabled,
+            @Value("${mixpanel.token}") String projectToken,
+            @Value("${mixpanel.residency}") String residency,
+            @Value("${mixpanel.verbose}") Boolean verbose,
+            @Value("${mixpanel.strict}") Boolean strict,
+            @Value("${mixpanel.timeoutMillis}") Integer timeoutMillis
     ) {
-        return new MixpanelEventPublisherAdapter(webClientBuilder.build(), mixpanelToken);
+        // 활성화 및 토큰 체크
+        if (Boolean.FALSE.equals(enabled)) {
+            log.warn("[Mixpanel] disabled by config. Tracking is OFF.");
+            return (eventType, distinctId, props) -> { /* no-op */ };
+        }
+        if (!StringUtils.hasText(projectToken)) {
+            log.warn("[Mixpanel] token is empty. Tracking will be skipped.");
+            return (eventType, distinctId, props) -> { /* no-op */ };
+        }
+
+        // 데이터 레지던시 이후 호스트 분기
+        final String host = "EU".equalsIgnoreCase(residency) ? HOST_EU : HOST_US;
+        log.info("[Mixpanel] enabled. host={}, verbose={}, strict={}, timeoutMillis={}",
+                host, verbose, strict, timeoutMillis);
+
+        return new MixpanelEventPublisherAdapter(
+                webClientBuilder.build(),
+                projectToken,
+                host,
+                verbose,
+                strict,
+                enabled,
+                timeoutMillis
+        );
     }
 }

--- a/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
+++ b/insty-external/src/main/java/insty/mixpanel/config/MixpanelConfig.java
@@ -1,0 +1,20 @@
+package insty.mixpanel.config;
+
+import insty.mixpanel.adapter.MixpanelEventPublisherAdapter;
+import insty.trackevent.port.AnalyticsEventPublisher;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class MixpanelConfig {
+
+    @Bean
+    public AnalyticsEventPublisher analyticsEventPublisher(
+            WebClient.Builder webClientBuilder,
+            @Value("${mixpanel.token:}") String mixpanelToken
+    ) {
+        return new MixpanelEventPublisherAdapter(webClientBuilder.build(), mixpanelToken);
+    }
+}

--- a/insty-external/src/main/java/insty/payment/kakaopay/config/KakaoPayRestClientConfig.java
+++ b/insty-external/src/main/java/insty/payment/kakaopay/config/KakaoPayRestClientConfig.java
@@ -3,6 +3,7 @@ package insty.payment.kakaopay.config;
 import insty.payment.kakaopay.properties.KakaoPayProperties;
 import java.net.http.HttpClient;
 import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,52 +12,101 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Configuration
 @EnableConfigurationProperties(KakaoPayProperties.class)
 public class KakaoPayRestClientConfig {
 
-    // 카카오페이 API 인증 헤더 키
-    private static final String HEADER_AUTHORIZATION = "Authorization";
-
-    // 카카오페이 인증 스킴 접두사
+    private static final String HEADER_AUTHORIZATION   = "Authorization";
+    private static final String HEADER_CONTENT_TYPE    = "Content-Type";
     private static final String AUTH_SCHEME_SECRET_KEY = "SECRET_KEY ";
 
-    // 카카오페이 전용 RestClient Bean 생성
-    @Bean(name = "kakaopayRestClient")
-    public RestClient kakaopayRestClient(KakaoPayProperties kakaoPayProperties) {
-        // KakaoPayProperties 기반으로 타임아웃 설정된 RequestFactory 생성
-        ClientHttpRequestFactory clientHttpRequestFactory = buildRequestFactory(kakaoPayProperties);
+    // yml에 설정이 따로 되어 있지 않을 경우 사용하는 기본값
+    private static final String DEFAULT_CONTENT_TYPE   = MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+    private static final String DEFAULT_HOST = "https://open-api.kakaopay.com";
+    private static final int DEFAULT_CONNECT_MILLIS = 3000;
+    private static final int DEFAULT_READ_MILLIS    = 5000;
 
-        // 카카오페이 API 전용 RestClient 빌드
-        return RestClient.builder()
-                .baseUrl(kakaoPayProperties.host()) // 카카오페이 API 기본 호스트
-                .requestFactory(clientHttpRequestFactory) // 타임아웃이 적용된 HTTP 클라이언트
-                .defaultHeader(HEADER_AUTHORIZATION, AUTH_SCHEME_SECRET_KEY + kakaoPayProperties.secretKey()) // 인증 헤더
-                .defaultHeader("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE) // 기본 Content-Type
-                .build();
+    // KakaoPay RestClient 빈 생성
+    // yml에 설정이 되어 있지 않아도 기본값으로 작동 (실 결제 연동은 불가능)
+    @Bean(name = "kakaopayRestClient")
+    public RestClient kakaopayRestClient(KakaoPayProperties kakaopayProperties) {
+        // host 값 설정 (미설정 시 기본 호스트 사용)
+        String host = resolveHost(kakaopayProperties);
+
+        // 타임아웃 값 설정 (미설정 시 기본값 사용)
+        ClientHttpRequestFactory requestFactory = buildRequestFactory(kakaopayProperties);
+
+        // RestClient 빌드 시작: 공통 Content-Type 설정
+        RestClient.Builder builder = RestClient.builder()
+                .baseUrl(host)
+                .requestFactory(requestFactory)
+                .defaultHeader(HEADER_CONTENT_TYPE, DEFAULT_CONTENT_TYPE);
+
+        // secretKey가 비어 있으면 헤더 생략 및 경고, 있다면 실제 Authorization 헤더 설정
+        String secretKey = (kakaopayProperties != null) ? kakaopayProperties.secretKey() : null;
+        if (secretKey == null || secretKey.isBlank()) {
+            log.warn("[KakaoPay] secretKey 미설정 상태로 동작합니다. 실제 결제 호출 시 401/권한 오류가 발생할 수 있습니다.");
+        } else {
+            builder = builder.defaultHeader(HEADER_AUTHORIZATION, AUTH_SCHEME_SECRET_KEY + secretKey);
+        }
+
+        // RestClient 인스턴스 생성
+        RestClient client = builder.build();
+
+        // 생성 결과 로그 및 리턴(최종 적용된 타임아웃 값 표기)
+        log.info("[KakaoPay] RestClient 생성 완료 - baseUrl={}, connectTimeout={}ms, readTimeout={}ms",
+                host, resolveConnectTimeout(kakaopayProperties), resolveReadTimeout(kakaopayProperties));
+        return client;
     }
 
-    // JDK HttpClient 기반 RequestFactory 생성 (연결/응답 타임아웃 적용)
+    // Timeout에 적용된 값을 사용해 RequestFactory를 생성한다.
     private ClientHttpRequestFactory buildRequestFactory(KakaoPayProperties kakaoPayProperties) {
-        // 연결 타임아웃 (ms), 값이 없으면 기본 3000
-        int connectTimeoutMillis = kakaoPayProperties.timeout().connectMillis() != null
-                ? kakaoPayProperties.timeout().connectMillis()
-                : 3000;
+        // 유효한 타임아웃 ms로 변환 (미설정 시 기본값)
+        int connectMs = resolveConnectTimeout(kakaoPayProperties);
+        int readMs    = resolveReadTimeout(kakaoPayProperties);
 
-        // 응답 타임아웃 (ms), 값이 없으면 기본 5000
-        int readTimeoutMillis = kakaoPayProperties.timeout().readMillis() != null
-                ? kakaoPayProperties.timeout().readMillis()
-                : 5000;
-
-        // JDK HttpClient 생성 (연결 타임아웃 적용)
+        // JDK HttpClient 생성: 연결 타임아웃 적용
         HttpClient httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofMillis(connectTimeoutMillis))
+                .connectTimeout(Duration.ofMillis(connectMs))
                 .build();
 
-        // JdkClientHttpRequestFactory 생성 및 응답 타임아웃 설정
-        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
-        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMillis));
+        // Spring RequestFactory 생성: 읽기 타임아웃 적용
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(Duration.ofMillis(readMs));
+        return factory;
+    }
 
-        return requestFactory;
+    // host 값을 최종 확정한다. 만약 yml 값이 비어 있으면 기본 호스트로 대체하고 WARN 로그를 남긴다.
+    private String resolveHost(KakaoPayProperties props) {
+        String host = (props != null) ? props.host() : null;
+        if (host == null || host.isBlank()) {
+            log.warn("[KakaoPay] host 미설정 → 기본 host({}) 사용", DEFAULT_HOST);
+            return DEFAULT_HOST;
+        }
+        return host;
+    }
+
+    // 연결 타임아웃(ms)을 최종 확정한다. 만약 yml 값이 null/0/음수면 기본값으로 대체하고 WARN 로그를 남긴다.
+    private int resolveConnectTimeout(KakaoPayProperties kakaoPayProperties) {
+        // null 및 음수, 0값 방어
+        if (kakaoPayProperties == null
+                || kakaoPayProperties.timeout() == null
+                || kakaoPayProperties.timeout().connectMillis() == null
+                || kakaoPayProperties.timeout().connectMillis() <= 0) {
+            log.warn("[KakaoPay] timeout.connect-millis 미설정 → 기본 {}ms 사용", DEFAULT_CONNECT_MILLIS);
+            return DEFAULT_CONNECT_MILLIS;
+        }
+        return kakaoPayProperties.timeout().connectMillis();
+    }
+
+    // 읽기 타임아웃(ms)을 최종 확정한다. 만약 yml 값이 null/0/음수면 기본값으로 대체하고 WARN 로그를 남긴다.
+    private int resolveReadTimeout(KakaoPayProperties kakaoPayProperties) {
+        if (kakaoPayProperties == null || kakaoPayProperties.timeout() == null || kakaoPayProperties.timeout().readMillis() == null
+                || kakaoPayProperties.timeout().readMillis() <= 0) {
+            log.warn("[KakaoPay] timeout.read-millis 미설정 → 기본 {}ms 사용", DEFAULT_READ_MILLIS);
+            return DEFAULT_READ_MILLIS;
+        }
+        return kakaoPayProperties.timeout().readMillis();
     }
 }


### PR DESCRIPTION
- controller이나 service에서 trackevent어노테이션을 추가하면, mixpanel을 통해 자동으로 이벤트가 추가되도록 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사용자 행동 이벤트 트래킹 도입: 메서드 주석 기반 트래킹(회원가입 등), 이벤트 타입 열거체 및 퍼블리셔(비동기 전송·재시도·로그 마스킹) 추가

- **Configuration**
  - Mixpanel 설정 추가(활성화, 토큰, 거주지역, verbose/strict, 타임아웃). 개발/테스트 기본값 비활성화

- **Refactor**
  - 결제 클라이언트 안정성 향상(기본 호스트·타임아웃 적용, 비밀키 미설정 시 인증 헤더 생략·경고)

- **Tests**
  - 이벤트 트래킹 동작 검증 단위 테스트 추가

- **Chores**
  - AOP 관련 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->