### PR TITLE
✨ Feat(mixpanel): 실패 이벤트 추가 및 일부 로직 수정

### DIFF
--- a/insty-api/src/main/java/insty/domain/user/controller/AccountController.java
+++ b/insty-api/src/main/java/insty/domain/user/controller/AccountController.java
@@ -35,7 +35,10 @@ public class AccountController implements AccountControllerDocs {
     private final AccountService accountService;
 
     @PostMapping
-    @TrackEvent(eventType = MixpanelEventType.AUTH_SIGNED_UP)
+    @TrackEvent(
+            successEventType = MixpanelEventType.AUTH_SIGNED_UP,
+            failureEventType = MixpanelEventType.AUTH_SIGNUP_FAILED
+    )
     public SuccessRes<UserCreateRes> signup(@Valid @RequestBody UserCreateReq req) {
         return SuccessRes.of(accountService.signup(req));
     }

--- a/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
+++ b/insty-api/src/main/java/insty/global/trackevent/UserActionTrackingAspect.java
@@ -6,7 +6,9 @@ import insty.trackevent.port.AnalyticsEventPublisher;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.lang.annotation.AfterReturning;
+import org.slf4j.MDC;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,6 +21,7 @@ import org.springframework.web.servlet.HandlerMapping;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Aspect
@@ -33,65 +36,170 @@ public class UserActionTrackingAspect {
     // Mixpanel 이벤트 지오IP 파싱용 표준 키
     private static final String PROP_IP = "ip";
     private static final String PROP_PATH = "path";
+    // 실패 이벤트에 사용(민감정보 금지, 클래스명 수준)
+    private static final String PROP_EXCEPTION = "exception";
+    private static final String PROP_INSERT_ID = "insert_id";
 
     private static final String HDR_X_FORWARDED_FOR = "X-Forwarded-For";
     private static final String HDR_X_REAL_IP = "X-Real-IP";
     private static final String HDR_CF_CONNECTING_IP = "CF-Connecting-IP";
     private static final String HDR_TRUE_CLIENT_IP = "True-Client-IP";
     private static final String HDR_FORWARDED = "Forwarded";   // RFC 7239: for=1.2.3.4;proto=https
+    private static final String PROP_TRACE_ID = "trace_id";
+    private static final String HDR_X_REQUEST_ID = "X-Request-Id";
 
     // external 모듈의 퍼블리셔 사용
     private final AnalyticsEventPublisher analyticsEventPublisher;
 
-    // @TrackEvent가 붙은 메서드가 정상 리턴된 경우만 처리
-    @AfterReturning(value = "@annotation(trackEvent)", argNames = "trackEvent")
-    public void publishMixpanelEvent(final TrackEvent trackEvent) {
+    // 실패 예외를 롤백 후 사용하기 위해 보관
+    private static final ThreadLocal<Exception> LAST_FAILURE = new ThreadLocal<>();
+
+    // @Around로 변경하여 성공/실패 모두 처리(트랜잭션 결과 기준 afterCompletion 사용)
+    @Around(value = "@annotation(trackEvent)")
+    public Object publishMixpanelEvent(final ProceedingJoinPoint pjp, final TrackEvent trackEvent) throws Throwable {
         // 인증 주체에서 memberId 추출
         Long authenticatedMemberId = extractAuthenticatedMemberId();
 
         // 현재 요청 객체 확보(Controller 경유 시)
         HttpServletRequest request = resolveCurrentHttpServletRequest();
 
-        // 이벤트 속성 구성
-        Map<String, Object> eventProperties = new HashMap<>();
+        // 이벤트 속성 구성(공통)
+        Map<String, Object> baseProperties = new HashMap<>();
         if (authenticatedMemberId != null) {
-            eventProperties.put(PROP_MEMBER_ID, authenticatedMemberId);
+            baseProperties.put(PROP_MEMBER_ID, authenticatedMemberId);
         }
         if (request != null) {
             if (trackEvent.includeHttpMethod()) {
-                eventProperties.put(PROP_HTTP_METHOD, request.getMethod());
+                baseProperties.put(PROP_HTTP_METHOD, request.getMethod());
             }
             if (trackEvent.includeRequestIp()) {
                 String clientIp = resolveClientIp(request);
                 if (clientIp != null && !clientIp.isBlank()) {
-                    eventProperties.put(PROP_IP, clientIp); // 여기서 $ip로 전달
+                    baseProperties.put(PROP_IP, clientIp); // 여기서 $ip로 전달
                 }
             }
-            eventProperties.put(PROP_PATH, request.getRequestURI());
-            eventProperties.putAll(extractPathVariables(request, trackEvent.includePathVars()));
+            if (trackEvent.includeEndpointPath()) { // 추가 옵션 처리
+                baseProperties.put(PROP_PATH, request.getRequestURI());
+            }
+            baseProperties.putAll(extractPathVariables(request, trackEvent.includePathVars()));
         }
 
-        // 이벤트 타입 결정
-        MixpanelEventType eventType = trackEvent.eventType();
+        // trace_id 채우기 (X-Request-Id 우선, 없으면 MDC("traceId"))
+        // 어노테이션 옵션이 true일 때만 trace_id를 붙임
+        if (trackEvent.includeTraceId()) {
+            String traceId = null;
+            // HTTP 요청이 있는 경우, 게이트웨이/프록시/로드밸런서가 심어 준 X-Request-Id 헤더를 먼저 사용
+            if (request != null) {
+                traceId = request.getHeader(HDR_X_REQUEST_ID);
+            }
+            // 헤더가 없거나 비어 있으면 애플리케이션 레벨의 추적 값으로 폴백
+            if (!isNotBlank(traceId)) {
+                try {
+                    traceId = MDC.get("traceId");
+                } catch (Throwable ignored) {}
+            }
+            if (isNotBlank(traceId)) {
+                baseProperties.put(PROP_TRACE_ID, traceId);
+            }
+        }
 
-        // 트랜잭션 커밋 이후 발행 보장(트랜잭션이 없으면 즉시 발행)
-        Runnable publishTask = () -> analyticsEventPublisher.publish(eventType, authenticatedMemberId, eventProperties);
-        // 커스텀 설정된 트랜잭션 매니저나 일부 비동기 환경에서는 실제 트랜잭션은 열려 있어도 동기화가 활성화되지 않을 수 있음
-        // 이 경우 이벤트 발행 자체가 실패하게 되므로, 동기화 여부를 함께 검사하고 비활성 시에는 즉시 실행으로 폴백하는 방어 로직
-        // TX + Sync O → 커밋 후 정확히 1회 발행
-        // TX O + Sync X → 예외 없이 즉시 발행(폴백)
-        // TX X → 즉시 발행
-        if (TransactionSynchronizationManager.isActualTransactionActive()
-                && TransactionSynchronizationManager.isSynchronizationActive()) {
+        // 트랜잭션 활성 여부
+        final boolean txActiveAndSync =
+                trackEvent.publishAfterCommitOnly() &&
+                        TransactionSynchronizationManager.isActualTransactionActive() &&
+                        TransactionSynchronizationManager.isSynchronizationActive();
+
+        // 트랜잭션이 활성화된 경우, '결과 확정 후' 발행을 위해 afterCompletion 등록
+        if (txActiveAndSync) {
+            final MixpanelEventType successType = trackEvent.successEventType();
+            final MixpanelEventType failureType = trackEvent.failureEventType();
+            final Long distinctIdOnSuccess = resolveDistinctIdForSuccess(trackEvent, authenticatedMemberId);
+            final Map<String, Object> snapshotProps = new HashMap<>(baseProperties);
+
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
-                public void afterCommit() {
-                    publishTask.run();
+                public void afterCompletion(int status) {
+                    try {
+                        if (status == TransactionSynchronization.STATUS_COMMITTED && successType != MixpanelEventType.NONE) {
+                            Map<String, Object> props = new HashMap<>(snapshotProps);
+                            props.put(PROP_INSERT_ID, UUID.randomUUID().toString());
+                            analyticsEventPublisher.publish(successType, distinctIdOnSuccess, props);
+                        } else if (status == TransactionSynchronization.STATUS_ROLLED_BACK && failureType != MixpanelEventType.NONE) {
+                            Map<String, Object> props = new HashMap<>(snapshotProps);
+                            props.put(PROP_INSERT_ID, UUID.randomUUID().toString());
+                            Exception ex = LAST_FAILURE.get();
+                            if (ex != null) {
+                                props.put(PROP_EXCEPTION, ex.getClass().getSimpleName()); // 민감정보 X
+                            }
+                            // 실패 시 퍼블리셔 구현에서 anonymous 처리 권장(null 전달)
+                            analyticsEventPublisher.publish(failureType, null, props);
+                        }
+                    } catch (Exception publishEx) {
+                        log.warn("[TrackEvent] publish afterCompletion error={}", publishEx.toString());
+                    } finally {
+                        LAST_FAILURE.remove();
+                    }
                 }
             });
-        } else {
-            publishTask.run();
         }
+
+        try {
+            // 실제 비즈니스 실행
+            Object result = pjp.proceed();
+
+            // 트랜잭션 없거나 동기화 비활성 시, 성공 이벤트 즉시 발행
+            if (!txActiveAndSync) {
+                MixpanelEventType successType = trackEvent.successEventType();
+                if (successType != MixpanelEventType.NONE) {
+                    Map<String, Object> props = new HashMap<>(baseProperties);
+                    props.put(PROP_INSERT_ID, UUID.randomUUID().toString());
+                    Long distinctId = resolveDistinctIdForSuccess(trackEvent, authenticatedMemberId);
+                    try {
+                        analyticsEventPublisher.publish(successType, distinctId, props);
+                    } catch (Exception publishEx) {
+                        log.warn("[TrackEvent] publish immediate success error type={} error={}",
+                                successType, publishEx.toString());
+                    }
+                }
+            }
+
+            return result;
+        } catch (IllegalArgumentException devError) {
+            // 개발 시 나온 오류의 경우, 이벤트를 발행하지 않고 IllegalArgumentException 반환
+            throw devError;
+
+        } catch (Exception ex) {
+            // 실패 예외 저장(롤백 후 afterCompletion에서 사용)
+            LAST_FAILURE.set(ex);
+
+            // 트랜잭션이 없으면(혹은 동기화 비활성) 즉시 실패 이벤트 발행으로 폴백
+            if (!txActiveAndSync && trackEvent.failureEventType() != MixpanelEventType.NONE) {
+                Map<String, Object> props = new HashMap<>(baseProperties);
+                props.put(PROP_INSERT_ID, UUID.randomUUID().toString());
+                props.put(PROP_EXCEPTION, ex.getClass().getSimpleName());
+                try {
+                    analyticsEventPublisher.publish(trackEvent.failureEventType(), null, props);
+                } catch (Exception publishEx) {
+                    log.warn("[TrackEvent] publish immediate failure error type={} error={}",
+                            trackEvent.failureEventType(), publishEx.toString());
+                } finally {
+                    LAST_FAILURE.remove();
+                }
+            }
+            throw ex;
+        } finally {
+            // 트랜잭션 경계가 아니었던 경우 등을 대비한 정리
+            if (!txActiveAndSync) {
+                LAST_FAILURE.remove();
+            }
+        }
+    }
+
+    // 성공 이벤트용 distinct_id 계산: 전략이 ANONYMOUS면 null, 아니면 인증된 memberId
+    private Long resolveDistinctIdForSuccess(TrackEvent trackEvent, Long authenticatedMemberId) {
+        return (trackEvent.distinctIdStrategy() == TrackEvent.DistinctIdStrategy.ANONYMOUS)
+                ? null
+                : authenticatedMemberId;
     }
 
     // SecurityContext 에서 memberId 추출

--- a/insty-api/src/test/java/insty/global/trackevent/UserActionTrackingAspectTest.java
+++ b/insty-api/src/test/java/insty/global/trackevent/UserActionTrackingAspectTest.java
@@ -6,14 +6,12 @@ import insty.trackevent.port.AnalyticsEventPublisher;
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
@@ -27,12 +25,17 @@ import org.springframework.web.servlet.HandlerMapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+// @Valid 바인딩/파싱/타입/인증/인가/404 등 컨트롤러 진입 전 예외는 집계하지 않음 (Advice에서 별도 보강해야 함)
+// 내부 비즈니스 로직에서의 성공/실패만 집계 (성공=커밋 후, 실패=롤백 후 또는 논TX 즉시)
+
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
 class UserActionTrackingAspectTest {
 
     @InjectMocks private UserActionTrackingAspect aspect;
+
     @Mock private AnalyticsEventPublisher analyticsEventPublisher;
+
     @Captor private ArgumentCaptor<MixpanelEventType> eventTypeCaptor;
     @Captor private ArgumentCaptor<Long> distinctIdCaptor;
     @Captor private ArgumentCaptor<Map<String, Object>> propertiesCaptor;
@@ -45,14 +48,15 @@ class UserActionTrackingAspectTest {
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.clearSynchronization();
         }
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+        // 테스트 편의상 활성 플래그도 원복
+        try {
             TransactionSynchronizationManager.setActualTransactionActive(false);
-        }
+        } catch (Throwable ignore) {}
     }
 
     @Test
         // 컨트롤러 경유 시 HTTP 메타데이터와 PathVariable 포함
-    void controllerIncludesHttpMeta() {
+    void controllerIncludesHttpMeta() throws Throwable {
         // given: 인증 주체/요청/PathVar 준비
         setPrincipal(777L);
         MockHttpServletRequest req = new MockHttpServletRequest();
@@ -61,10 +65,20 @@ class UserActionTrackingAspectTest {
         req.setRemoteAddr("203.0.113.10");
         req.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("courseId", "123"));
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
-        TrackEvent ev = stub(MixpanelEventType.COURSE_VIEWED, new String[]{"courseId"}, true, true);
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenReturn(new Object()); // 정상 리턴
+
+        TrackEvent ev = stub(
+                MixpanelEventType.COURSE_LEARNING_STARTED,
+                MixpanelEventType.NONE,
+                new String[]{"courseId"},
+                // TX가 없을 경우 즉시 발행
+                true, true, true, false
+        );
 
         // when: 어드바이스 호출
-        aspect.publishMixpanelEvent(ev);
+        aspect.publishMixpanelEvent(pjp, ev);
 
         // then: 이벤트 1회 발행 및 필드 검증
         verify(analyticsEventPublisher).publish(
@@ -73,18 +87,21 @@ class UserActionTrackingAspectTest {
                 propertiesCaptor.capture()
         );
         Map<String, Object> props = propertiesCaptor.getValue();
-        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_VIEWED);
+        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.COURSE_LEARNING_STARTED);
         assertThat(distinctIdCaptor.getValue()).isEqualTo(777L);
         assertThat(props.get("memberId")).isEqualTo(777L);
         assertThat(props.get("httpMethod")).isEqualTo("GET");
         assertThat(props.get("ip")).isEqualTo("203.0.113.10");
         assertThat(props.get("path")).isEqualTo("/api/courses/123");
         assertThat(String.valueOf(props.get("courseId"))).isEqualTo("123");
+        // insert_id 는 매번 새 UUID
+        assertThat(props.get("insert_id")).isInstanceOf(String.class);
+        assertThat(((String) props.get("insert_id"))).hasSizeGreaterThan(10);
     }
 
     @Test
         // X-Forwarded-For 헤더가 있으면 첫 번째 IP 우선 사용
-    void prefersXff() {
+    void prefersXff() throws Throwable {
         // given: XFF 헤더 포함 요청
         setPrincipal(101L);
         MockHttpServletRequest req = new MockHttpServletRequest();
@@ -93,10 +110,19 @@ class UserActionTrackingAspectTest {
         req.setRemoteAddr("10.0.0.5");
         req.addHeader("X-Forwarded-For", "118.47.11.208, 203.0.113.9");
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
-        TrackEvent ev = stub(MixpanelEventType.COURSE_VIEWED, new String[]{}, true, true);
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenReturn(new Object());
+
+        TrackEvent ev = stub(
+                MixpanelEventType.COURSE_LEARNING_STARTED,
+                MixpanelEventType.NONE,
+                new String[]{},
+                true, true, true, false
+        );
 
         // when
-        aspect.publishMixpanelEvent(ev);
+        aspect.publishMixpanelEvent(pjp, ev);
 
         // then
         verify(analyticsEventPublisher).publish(any(), any(), propertiesCaptor.capture());
@@ -105,7 +131,7 @@ class UserActionTrackingAspectTest {
 
     @Test
         // Forwarded 헤더(for=...)에서 클라이언트 IP 파싱
-    void parsesForwarded() {
+    void parsesForwarded() throws Throwable {
         // given: Forwarded 헤더 포함 요청
         setPrincipal(102L);
         MockHttpServletRequest req = new MockHttpServletRequest();
@@ -114,10 +140,19 @@ class UserActionTrackingAspectTest {
         req.setRemoteAddr("10.0.0.6");
         req.addHeader("Forwarded", "for=\"203.0.113.195:1234\";proto=https, for=70.41.3.18");
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
-        TrackEvent ev = stub(MixpanelEventType.COURSE_VIEWED, new String[]{}, true, true);
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenReturn(new Object());
+
+        TrackEvent ev = stub(
+                MixpanelEventType.COURSE_LEARNING_STARTED,
+                MixpanelEventType.NONE,
+                new String[]{},
+                true, true, true, false
+        );
 
         // when
-        aspect.publishMixpanelEvent(ev);
+        aspect.publishMixpanelEvent(pjp, ev);
 
         // then
         verify(analyticsEventPublisher).publish(any(), any(), propertiesCaptor.capture());
@@ -126,23 +161,31 @@ class UserActionTrackingAspectTest {
 
     @Test
         // 서비스 계층에서 트랜잭션이 있을 경우, 커밋 후 발행
-    void afterCommitInService() {
+    void afterCommitInService() throws Throwable {
         // given: 트랜잭션 활성화
         setPrincipal(888L);
         RequestContextHolder.resetRequestAttributes();
-        TrackEvent ev = stub(MixpanelEventType.COURSE_LEARNING_STARTED, new String[]{}, false, false);
+        TrackEvent ev = stub(
+                MixpanelEventType.COURSE_LEARNING_STARTED,
+                MixpanelEventType.NONE,
+                new String[]{},
+                false, false, false, true // http/ip/path 제외, afterCommit만
+        );
         TransactionSynchronizationManager.initSynchronization();
         TransactionSynchronizationManager.setActualTransactionActive(true);
 
-        // when: 커밋 전 호출
-        aspect.publishMixpanelEvent(ev);
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenReturn("ok");
 
-        // then: 커밋 전에는 발행 안 됨
+        // when: 호출 (커밋 전에는 발행 X)
+        aspect.publishMixpanelEvent(pjp, ev);
+
         verify(analyticsEventPublisher, times(0)).publish(any(), any(), any());
 
         // when: 커밋 시뮬레이션
         List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
-        syncs.forEach(TransactionSynchronization::afterCommit);
+        // afterCompletion(STATUS_COMMITTED) 로 확정
+        syncs.forEach(s -> s.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
         TransactionSynchronizationManager.clearSynchronization();
         TransactionSynchronizationManager.setActualTransactionActive(false);
 
@@ -159,18 +202,68 @@ class UserActionTrackingAspectTest {
         assertThat(props.containsKey("httpMethod")).isFalse();
         assertThat(props.containsKey("path")).isFalse();
         assertThat(props.containsKey("ip")).isFalse();
+        assertThat(props.get("insert_id")).isInstanceOf(String.class);
     }
 
     @Test
-        // 트랜잭션 없음: 즉시 발행
-    void immediateNoTx() {
+        // 트랜잭션 롤백: 실패 이벤트는 롤백 후 1회 발행
+    void afterRollbackPublishesFailure() throws Throwable {
+        // given: 트랜잭션 활성 + 실패 시나리오
+        setPrincipal(111L);
+        RequestContextHolder.resetRequestAttributes();
+        TrackEvent ev = stub(
+                MixpanelEventType.AUTH_SIGNED_UP,
+                MixpanelEventType.AUTH_SIGNUP_FAILED,
+                new String[]{},
+                false, false, false, true // afterCommitOnly=true
+        );
+        TransactionSynchronizationManager.initSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenThrow(new IllegalStateException("boom"));
+
+        // when: 호출 → 예외 재던짐 (테스트에서는 잡지 않고 흘려보냄)
+        try {
+            aspect.publishMixpanelEvent(pjp, ev);
+        } catch (Exception ignored) {}
+
+        // 롤백 확정
+        List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
+        syncs.forEach(s -> s.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK));
+        TransactionSynchronizationManager.clearSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+
+        // then: 실패 이벤트 1회 발행, distinct_id는 null(퍼블리셔에서 anonymous 처리 가정)
+        verify(analyticsEventPublisher).publish(
+                eventTypeCaptor.capture(),
+                distinctIdCaptor.capture(),
+                propertiesCaptor.capture()
+        );
+        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.AUTH_SIGNUP_FAILED);
+        assertThat(distinctIdCaptor.getValue()).isNull();
+        assertThat(propertiesCaptor.getValue().get("exception")).isEqualTo("IllegalStateException");
+        assertThat(propertiesCaptor.getValue().get("insert_id")).isInstanceOf(String.class);
+    }
+
+    @Test
+        // 트랜잭션 없음: 즉시 발행 (성공)
+    void immediateSuccessNoTx() throws Throwable {
         // given: 트랜잭션/요청컨텍스트 없음
         setPrincipal(999L);
         RequestContextHolder.resetRequestAttributes();
-        TrackEvent ev = stub(MixpanelEventType.AUTH_LOGGED_IN, new String[]{}, false, false);
+        TrackEvent ev = stub(
+                MixpanelEventType.AUTH_LOGGED_IN,
+                MixpanelEventType.NONE,
+                new String[]{},
+                false, false, false, false // afterCommitOnly=false → 즉시 발행
+        );
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenReturn("ok");
 
         // when
-        aspect.publishMixpanelEvent(ev);
+        aspect.publishMixpanelEvent(pjp, ev);
 
         // then
         verify(analyticsEventPublisher).publish(
@@ -182,7 +275,43 @@ class UserActionTrackingAspectTest {
         assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.AUTH_LOGGED_IN);
         assertThat(distinctIdCaptor.getValue()).isEqualTo(999L);
         assertThat(props.get("memberId")).isEqualTo(999L);
+        assertThat(props.get("insert_id")).isInstanceOf(String.class);
     }
+
+    @Test
+        // 트랜잭션 없음: 즉시 발행 (실패)
+    void immediateFailureNoTx() throws Throwable {
+        // given
+        setPrincipal(1001L);
+        RequestContextHolder.resetRequestAttributes();
+        TrackEvent ev = stub(
+                MixpanelEventType.AUTH_SIGNED_UP,
+                MixpanelEventType.AUTH_SIGNUP_FAILED,
+                new String[]{},
+                false, false, false, false // afterCommitOnly=false
+        );
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        when(pjp.proceed()).thenThrow(new RuntimeException("fail"));
+
+        // when
+        try {
+            aspect.publishMixpanelEvent(pjp, ev);
+        } catch (Exception ignored) {}
+
+        // then: 즉시 실패 발행
+        verify(analyticsEventPublisher).publish(
+                eventTypeCaptor.capture(),
+                distinctIdCaptor.capture(),
+                propertiesCaptor.capture()
+        );
+        assertThat(eventTypeCaptor.getValue()).isEqualTo(MixpanelEventType.AUTH_SIGNUP_FAILED);
+        assertThat(distinctIdCaptor.getValue()).isNull();
+        assertThat(propertiesCaptor.getValue().get("exception")).isEqualTo("RuntimeException");
+        assertThat(propertiesCaptor.getValue().get("insert_id")).isInstanceOf(String.class);
+    }
+
+    // 테스트에 사용하는 유틸 ---
 
     // 간단한 Principal 스텁(Aspect가 getMemberId 리플렉션 호출)
     private interface HasMemberId { Long getMemberId(); }
@@ -195,13 +324,26 @@ class UserActionTrackingAspectTest {
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
-    // @TrackEvent 익명 구현체 스텁
-    private TrackEvent stub(MixpanelEventType type, String[] pathVars, boolean includeIp, boolean includeMethod) {
+    // @TrackEvent 익명 구현체 스텁 (새 시그니처 반영)
+    private TrackEvent stub(MixpanelEventType success,
+                            MixpanelEventType failure,
+                            String[] pathVars,
+                            boolean includeIp,
+                            boolean includeMethod,
+                            boolean includeEndpointPath,
+                            boolean publishAfterCommitOnly) {
         return new TrackEvent() {
-            @Override public MixpanelEventType eventType() { return type; }
+            @Override public MixpanelEventType successEventType() { return success; }
+            @Override public MixpanelEventType failureEventType() { return failure; }
             @Override public String[] includePathVars() { return pathVars; }
             @Override public boolean includeRequestIp() { return includeIp; }
             @Override public boolean includeHttpMethod() { return includeMethod; }
+            @Override public boolean includeEndpointPath() { return includeEndpointPath; }
+            @Override public boolean includeTraceId() { return false; }
+            @Override public boolean publishAfterCommitOnly() { return publishAfterCommitOnly; }
+            @Override public TrackEvent.DistinctIdStrategy distinctIdStrategy() {
+                return TrackEvent.DistinctIdStrategy.SECURITY_CONTEXT_MEMBER_ID;
+            }
             @Override public Class<? extends Annotation> annotationType() { return TrackEvent.class; }
         };
     }

--- a/insty-common/src/main/java/insty/trackevent/TrackEvent.java
+++ b/insty-common/src/main/java/insty/trackevent/TrackEvent.java
@@ -9,15 +9,29 @@ import java.lang.annotation.*;
 @Documented                               // Javadoc 문서에 포함
 public @interface TrackEvent {
 
-    // 발행할 이벤트 종류(필수)
-    MixpanelEventType eventType();
+    // 성공 시 발행할 이벤트 (필수)
+    MixpanelEventType successEventType();
 
-    // 이벤트 속성에 포함할 PathVariable 키 배열
+    // 실패 시 발행할 이벤트 (선택) - 지정 시 예외 발생하면 실패 이벤트 발행
+    MixpanelEventType failureEventType() default MixpanelEventType.NONE;
+
+    // PathVariable 키 배열(성공/실패 공통으로 properties에 포함)
     String[] includePathVars() default {};
 
-    // 요청 IP를 이벤트 속성에 포함할지 여부
+    // IP, HTTP, 엔드포인트 등 부가정보 저장
     boolean includeRequestIp() default true;
-
-    // HTTP 메서드(GET/POST 등) 포함 여부
     boolean includeHttpMethod() default true;
+    boolean includeEndpointPath() default true;
+    boolean includeTraceId() default true;
+
+    // 트랜잭션 커밋 이후에만 발행할지 여부
+    boolean publishAfterCommitOnly() default true;
+
+    // distinct_id 계산 전략: SECURITY_CONTEXT_MEMBER_ID | ANONYMOUS
+    DistinctIdStrategy distinctIdStrategy() default DistinctIdStrategy.SECURITY_CONTEXT_MEMBER_ID;
+
+    enum DistinctIdStrategy {
+        SECURITY_CONTEXT_MEMBER_ID, // AuthenticationMember에서 memberId 추출
+        ANONYMOUS                   // 실패 등 memberId 없는 경우
+    }
 }

--- a/insty-common/src/main/java/insty/trackevent/model/MixpanelEventType.java
+++ b/insty-common/src/main/java/insty/trackevent/model/MixpanelEventType.java
@@ -3,17 +3,26 @@ package insty.trackevent.model;
 // 이벤트 네이밍: <DOMAIN>_<ACTION>_<RESULT/STATE>
 public enum MixpanelEventType {
 
+    // 공용
+    NONE,                       // 이벤트에 사용하는 용도가 아닌, 내부 처리용
+
     // USER
-    AUTH_SIGNED_UP,          // 회원가입 완료
-    AUTH_LOGGED_IN,          // 로그인 성공
-    AUTH_EMAIL_VERIFIED,     // 이메일 인증 완료
+    AUTH_SIGNED_UP,             // 회원가입 완료(성공)
+    AUTH_SIGNUP_FAILED,         // 회원가입 실패(롤백/예외)
+    AUTH_LOGGED_IN,             // 로그인 성공
+    AUTH_LOGIN_FAILED,          // 로그인 실패
+    AUTH_EMAIL_VERIFIED,        // 이메일 인증 완료
+    AUTH_EMAIL_VERIFY_FAILED,   // 이메일 인증 실패
 
     // COURSE
-    COURSE_VIEWED,           // 강의 상세 진입
-    COURSE_LEARNING_STARTED, // 강의 수강 시작
+    COURSE_LEARNING_STARTED,       // 강의 수강 시작(성공: 등록/진행 상태 전이 커밋 후)
+    COURSE_LEARNING_START_FAILED,  // 강의 수강 시작 실패(등록/상태 전이 실패)
 
     // COMMUNITY
-    COMMUNITY_QUESTION_CREATED, // 질문 작성
-    COMMUNITY_ANSWER_CREATED,   // 답변 작성
-    COMMUNITY_ANSWER_ACCEPTED   // 답변 채택
+    COMMUNITY_QUESTION_CREATED,    // 질문 작성 성공
+    COMMUNITY_QUESTION_CREATE_FAILED, // 질문 작성 실패
+    COMMUNITY_ANSWER_CREATED,      // 답변 작성 성공
+    COMMUNITY_ANSWER_CREATE_FAILED,// 답변 작성 실패
+    COMMUNITY_ANSWER_ACCEPTED,     // 답변 채택 성공
+    COMMUNITY_ANSWER_ACCEPT_FAILED // 답변 채택 실패
 }


### PR DESCRIPTION
- 트랜잭션/동기화 없을 시, 성공/실패 이벤트 즉시 발행
- trace_id 주입을 통해 grafana등이랑 연동 용이하게 처리
- 테스트 보강

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 성공/실패를 별도 이벤트로 수집하고, 커밋 후 발행 옵션으로 기록의 일관성을 강화했습니다.
  * 요청 경로/경로변수/IP/HTTP 메서드/trace id를 선택적으로 포함할 수 있습니다.
  * 익명/회원 기반 식별 전략을 지원하고 모든 이벤트에 고유 insert_id를 포함합니다.
  * 회원가입/로그인/학습 시작 등 도메인별 실패 이벤트 유형을 추가했습니다.
* Refactor
  * 성공/실패를 모두 포착하는 추적 흐름으로 통합하고 공통 속성 구성을 단일화했습니다.
* Tests
  * 트랜잭션 커밋/롤백 및 비트랜잭션 시나리오 테스트를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->