### PR TITLE
🐛 Fix(커뮤니티): Swagger 코멘트 수정 (null이면 삭제 임을 명시)

### DIFF
--- a/insty-api/src/main/java/insty/domain/community/dto/CommunityAnswerUpdateReq.java
+++ b/insty-api/src/main/java/insty/domain/community/dto/CommunityAnswerUpdateReq.java
@@ -10,7 +10,7 @@ public record CommunityAnswerUpdateReq(
         @Schema(description = "답변 내용", example = "이 문제는 다음과 같이 해결할 수 있습니다.")
         String content,
 
-        @Schema(description = "답변에 첨부할 비디오 UUID (null이면 기존 영상 유지)", example = "123e4567-e89b-12d3-a456-426614174000")
+        @Schema(description = "답변에 첨부할 비디오 UUID (null이면 기존 영상 삭제)", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID videoUuid,
 
         @Schema(description = "삭제할 파일 ID 목록 (첨부 제한 1개 기준으로 최종 개수 검증)", example = "[1, 2, 3]")

--- a/insty-api/src/main/java/insty/domain/community/dto/CommunityQuestionUpdateReq.java
+++ b/insty-api/src/main/java/insty/domain/community/dto/CommunityQuestionUpdateReq.java
@@ -15,7 +15,7 @@ public record CommunityQuestionUpdateReq(
         @Schema(description = "질문 내용", example = "스프링 부트에서 JPA를 사용할 때 발생하는 문제입니다.")
         String content,
 
-        @Schema(description = "질문에 첨부할 비디오 UUID (null이면 기존 영상 유지)", example = "123e4567-e89b-12d3-a456-426614174000")
+        @Schema(description = "질문에 첨부할 비디오 UUID (null이면 기존 영상 삭제)", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID videoUuid,
 
         @Schema(description = "삭제할 파일 ID 목록 (추가 업로드와 합산해 최종 2개 제한 적용)", example = "[1, 2, 3]")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서화
  * 커뮤니티 질문/답변 수정 API의 videoUuid 필드 설명을 업데이트했습니다. 이제 null일 경우 기존 영상이 삭제됨을 명확히 표기했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->