### PR TITLE
🔧 Chore: 영상 일일 최대 용량 조정(dev한정)

### DIFF
--- a/insty-api/src/main/resources/application-dev.yml
+++ b/insty-api/src/main/resources/application-dev.yml
@@ -13,9 +13,9 @@ swagger:
 video:
   upload:
     max-minute:
-      course: 60
-      answer: 60
-      question: 60
+      course: 6000
+      answer: 6000
+      question: 6000
 
 mixpanel:
   enabled: false


### PR DESCRIPTION
- 60분에서 6000분(100시간이므로, 사실상 한도 삭제)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 비디오 업로드 최대 시간이 확대되었습니다. 코스, 답변, 질문 카테고리의 비디오 세그먼트 업로드 시간 제한이 60분에서 6000분으로 증가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->